### PR TITLE
Fix check_teleId trigger

### DIFF
--- a/prisma/migrations/20221206162651_added_tele_id_trigger/migration.sql
+++ b/prisma/migrations/20221206162651_added_tele_id_trigger/migration.sql
@@ -1,8 +1,9 @@
 /*
- Prevents updates on teleIDs where the teleID is not null
+ Prevents changes to teleIDs when the teleID is not null
  */
 CREATE
-OR REPLACE FUNCTION check_teleId() RETURNS TRIGGER AS $ $ BEGIN IF (OLD."telegramId" is NULL) THEN RETURN NEW;
+OR REPLACE FUNCTION check_teleId() RETURNS TRIGGER AS $$ BEGIN IF (OLD."telegramId" is NULL)
+OR (OLD."telegramId" = NEW."telegramId") THEN RETURN NEW;
 
 END IF;
 
@@ -10,7 +11,7 @@ RETURN NULL;
 
 END;
 
-$ $ LANGUAGE plpgsql;
+$$ LANGUAGE plpgsql;
 
 CREATE TRIGGER update_telegramId BEFORE
 UPDATE


### PR DESCRIPTION
This PR fixes the check_teleId() trigger to allow updates on fields that are not "telegramId" so that mutable fields such as telegram user name can be changed.

