### PR TITLE
Add route for getting all organiston details

### DIFF
--- a/src/controllers/organisation.ts
+++ b/src/controllers/organisation.ts
@@ -1,0 +1,23 @@
+import { Response, Request, NextFunction } from 'express'
+import { HttpCode, HttpException } from '@exceptions/HttpException'
+import { Organisation } from '@prisma/client'
+import { getAllOrgs } from '@/services/organisations'
+
+/**
+ * Retrieves all organisation details
+ * @param req not used
+ * @param res json with all organisation details
+ * @param next
+ */
+export async function getOrgs(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> {
+  try {
+    const orgs = await getAllOrgs()
+    res.json(orgs)
+  } catch (error) {
+    next(error)
+  }
+}

--- a/src/routes/routes.ts
+++ b/src/routes/routes.ts
@@ -13,6 +13,7 @@ import {
   editBooking,
   deleteBookingHandler,
 } from '../controllers/bookings'
+import { getOrgs } from '@/controllers/organisation'
 
 export const router: Router = Router()
 
@@ -24,6 +25,10 @@ const asyncHandler =
 
 // login route
 router.post('/login', asyncHandler(handleLogin))
+
+// get description of all Organisations
+// authentication not needed
+router.get('/orgs', asyncHandler(getOrgs))
 
 // create a booking
 router.post('/bookings', requiresAuthentication, asyncHandler(createBooking))

--- a/src/services/organisations.ts
+++ b/src/services/organisations.ts
@@ -1,0 +1,8 @@
+import prisma from './db'
+import { Organisation } from '@prisma/client'
+import { HttpCode, HttpException } from '@/exceptions/HttpException'
+
+/* Retrieves all organisations */
+export async function getAllOrgs(): Promise<Organisation[]> {
+  return await prisma.organisation.findMany()
+}


### PR DESCRIPTION
This PR adds a route for getting all organisation details.

It is very likely that the pictures will be cached in the repo (and potentially the descriptions too) for the launch. But it is still good to get the route out in the meanwhile.

Closes @43