### PR TITLE
test: add unit tests for controllers and policies

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -26,9 +26,7 @@ const config = {
   coverageDirectory: 'coverage',
 
   // An array of regexp pattern strings used to skip coverage collection
-  // coveragePathIgnorePatterns: [
-  //   "/node_modules/"
-  // ],
+  coveragePathIgnorePatterns: ['/node_modules/', '\\.interface\\.ts$'],
 
   // Indicates which provider should be used to instrument code for coverage
   // coverageProvider: 'v8',
@@ -170,9 +168,7 @@ const config = {
   // ],
 
   // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
-  // testPathIgnorePatterns: [
-  //   "/node_modules/"
-  // ],
+  testPathIgnorePatterns: ['/node_modules/'],
 
   // The regexp pattern or array of patterns that Jest uses to detect test files
   // testRegex: [],

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "src/app.js",
   "scripts": {
     "test:unit": "jest -c ./jest.config.js --coverage --verbose",
+    "test:unit:watch": "jest -c ./jest.config.js --watch",
     "build": "npm run prisma:generate && tsc",
     "start": "npm run build && node -r ts-node/register/transpile-only -r tsconfig-paths/register dist/src/app.js",
     "dev": "cross-env NODE_ENV=development nodemon",

--- a/src/controllers/booking/delete.test.ts
+++ b/src/controllers/booking/delete.test.ts
@@ -1,0 +1,177 @@
+import { getBookingById } from '../../services/bookings'
+import { getMockReq, getMockRes } from '@jest-mock/express'
+import * as Policy from '../../policy'
+import { RequestWithUser } from '../../interfaces/auth.interface'
+import {
+  HttpCode,
+  HttpException,
+  UnauthorizedException,
+} from '../../exceptions/'
+import { deleteBooking } from '.'
+import {
+  generateRandomAbility,
+  generateRandomBooking,
+  generateRandomOrganisation,
+  generateRandomRole,
+  generateRandomUser,
+} from '../../services/test/utils'
+import {
+  getUserAbilities,
+  getUserOrgs,
+  getUserRoles,
+} from '../../services/users'
+
+jest.mock('../../services/users', () => ({
+  getUserAbilities: jest.fn(),
+  getUserRoles: jest.fn(),
+  getUserOrgs: jest.fn(),
+}))
+
+jest.mock('../../services/bookings', () => ({
+  destroyBooking: jest.fn(),
+  getBookingById: jest.fn(),
+}))
+
+afterEach(() => {
+  jest.resetAllMocks()
+})
+
+describe('Test delete booking handler', () => {
+  const memberUser = generateRandomUser({ id: 1 })
+  const userWhoMadeBooking = generateRandomUser({ id: 2 })
+  const mockBookingId = 123
+
+  const orgId = 1
+  const mockBooking = generateRandomBooking({
+    id: mockBookingId,
+    userId: 2,
+    userOrgId: orgId,
+  })
+  const orgHeadOrg = generateRandomOrganisation({ id: orgId })
+
+  test('Should return 400 if booking id is invalid', async () => {
+    const { res } = getMockRes()
+    const req = getMockReq<RequestWithUser>({
+      params: { id: 'hello' },
+    })
+
+    try {
+      await deleteBooking(req, res)
+    } catch (e) {
+      const exception = e as HttpException
+      expect(exception).toBeInstanceOf(HttpException)
+      expect(exception.status).toBe(HttpCode.BadRequest)
+      expect(exception.message).toMatch(/Invalid booking id/i)
+    }
+  })
+
+  // DESCRIBE: Member
+  // DESCRIBE: Org Head
+  // DESCRIBE: Booking Admin
+
+  test('Should return 401 not authorized if user is not logged in', async () => {
+    const { res } = getMockRes()
+    const req = getMockReq<RequestWithUser>({
+      params: { id: mockBookingId.toString() },
+    })
+
+    try {
+      await deleteBooking(req, res)
+    } catch (e) {
+      const exception = e as HttpException
+      expect(exception).toBeInstanceOf(HttpException)
+      expect(exception.status).toBe(HttpCode.Unauthorized)
+      expect(exception.message).toMatch(/Requires authentication/i)
+    }
+  })
+
+  test('Should return 401 not authorized if user did not make booking', async () => {
+    const { res } = getMockRes()
+    const req = getMockReq<RequestWithUser>({
+      user: memberUser,
+      params: { id: mockBookingId.toString() },
+    })
+
+    jest.mocked(getUserAbilities).mockResolvedValue([])
+    jest.mocked(getUserRoles).mockResolvedValue([])
+    jest.mocked(getBookingById).mockResolvedValue(mockBooking)
+    jest.mocked(getUserOrgs).mockResolvedValue([])
+
+    try {
+      await deleteBooking(req, res)
+    } catch (e) {
+      const exception = e as HttpException
+      expect(exception).toBeInstanceOf(UnauthorizedException)
+      expect(exception.status).toBe(HttpCode.Unauthorized)
+      expect(exception.message).toMatch(/You are not authorized to/i)
+    }
+  })
+
+  // TODO: Allow members who book certain places to delete their own booking
+  test.todo('Success if member tries to delete their own booking')
+
+  test('Success if org head tries to delete booking in their org', async () => {
+    const { res } = getMockRes()
+    const req = getMockReq<RequestWithUser>({
+      user: userWhoMadeBooking,
+      params: { id: mockBookingId.toString() },
+    })
+
+    jest.mocked(getUserAbilities).mockResolvedValue([])
+    jest
+      .mocked(getUserRoles)
+      .mockResolvedValue([generateRandomRole(Policy.OrganisationHeadRole)])
+
+    jest.mocked(getBookingById).mockResolvedValue(mockBooking)
+    jest.mocked(getUserOrgs).mockResolvedValue([orgHeadOrg])
+
+    await deleteBooking(req, res)
+    expect(res.status).toBeCalledWith(HttpCode.OK)
+  })
+
+  test('Should return 401 not authorized if org head tries to delete booking in another org', async () => {
+    const { res } = getMockRes()
+    const req = getMockReq<RequestWithUser>({
+      user: userWhoMadeBooking,
+      params: { id: mockBookingId.toString() },
+    })
+
+    jest.mocked(getUserAbilities).mockResolvedValue([])
+    jest
+      .mocked(getUserRoles)
+      .mockResolvedValue([generateRandomRole(Policy.OrganisationHeadRole)])
+    jest.mocked(getBookingById).mockResolvedValue(mockBooking)
+    jest
+      .mocked(getUserOrgs)
+      .mockResolvedValue([generateRandomOrganisation({ id: 3 })])
+
+    try {
+      await deleteBooking(req, res)
+    } catch (e) {
+      const exception = e as HttpException
+      expect(exception).toBeInstanceOf(UnauthorizedException)
+      expect(exception.status).toBe(HttpCode.Unauthorized)
+      expect(exception.message).toMatch(/You are not authorized to/i)
+    }
+  })
+
+  test('Success if bookingAdmin tries to delete booking', async () => {
+    const { res } = getMockRes()
+    const req = getMockReq<RequestWithUser>({
+      user: userWhoMadeBooking,
+      params: { id: mockBookingId.toString() },
+    })
+
+    jest
+      .mocked(getUserAbilities)
+      .mockResolvedValue([
+        generateRandomAbility(Policy.canDeleteBookingAbility),
+      ])
+    jest.mocked(getUserRoles).mockResolvedValue([])
+    jest.mocked(getBookingById).mockResolvedValue(mockBooking)
+    jest.mocked(getUserOrgs).mockResolvedValue([])
+
+    await deleteBooking(req, res)
+    expect(res.status).toBeCalledWith(HttpCode.OK)
+  })
+})

--- a/src/controllers/booking/delete.ts
+++ b/src/controllers/booking/delete.ts
@@ -28,5 +28,5 @@ export async function deleteBooking(
   )
 
   const deletedBooking = await destroyBooking(bookingId, req.user.id)
-  res.json(deletedBooking)
+  res.status(200).json(deletedBooking)
 }

--- a/src/controllers/booking/list.test.ts
+++ b/src/controllers/booking/list.test.ts
@@ -1,0 +1,105 @@
+import { Request, Response } from 'express'
+import { HttpCode, HttpException } from '../../exceptions/HttpException'
+import { listBookings, getUserBookingsController } from './list'
+import { getMockReq, getMockRes } from '@jest-mock/express'
+import * as Policy from '../../policy'
+import { generateRandomBooking } from '../../services/test/utils'
+import { getAllBookings, getUserBookings } from '../../services/bookings'
+
+jest.mock('../../services/bookings', () => ({
+  getUserBookings: jest.fn(),
+  getAllBookings: jest.fn(),
+}))
+
+afterEach(() => {
+  jest.resetAllMocks()
+})
+
+describe('listBookings', () => {
+  const mockStartDate = '2024-02-10T00:00:00Z'
+  const mockEndDate = '2024-02-11T00:00:00Z'
+
+  test('Should throw HttpException if start date is invalid', async () => {
+    const { res } = getMockRes()
+    const req = getMockReq<Request>({
+      query: { start: 'hello', end: mockEndDate },
+    })
+
+    try {
+      await listBookings(req, res)
+    } catch (e) {
+      const exception = e as HttpException
+      expect(exception).toBeInstanceOf(HttpException)
+      expect(exception.status).toBe(HttpCode.BadRequest)
+      expect(exception.message).toMatch(
+        /Query start is not a valid date string/i
+      )
+    }
+  })
+
+  test('Should throw HttpException if end date is invalid', async () => {
+    const { res } = getMockRes()
+    const req = getMockReq<Request>({
+      query: { start: mockStartDate, end: 'hello' },
+    })
+
+    try {
+      await listBookings(req, res)
+    } catch (e) {
+      const exception = e as HttpException
+      expect(exception).toBeInstanceOf(HttpException)
+      expect(exception.status).toBe(HttpCode.BadRequest)
+      expect(exception.message).toMatch(/Query end is not a valid date string/i)
+    }
+  })
+
+  describe('Not a user', () => {
+    test('Should return bookings within the given date range if date range is valid', async () => {
+      const { res } = getMockRes()
+      const req = getMockReq<Request>({
+        query: { start: mockStartDate, end: mockEndDate },
+      })
+
+      const mockBookings = [generateRandomBooking(), generateRandomBooking()]
+      jest.mocked(getAllBookings).mockResolvedValue(mockBookings)
+
+      await listBookings(req, res)
+
+      expect(res.json).toHaveBeenCalledWith(mockBookings)
+    })
+  })
+})
+
+describe('getUserBookingsController', () => {
+  test('Should throw HttpException if userId is missing', async () => {
+    const { res } = getMockRes()
+    const req = getMockReq<Request>({
+      query: {},
+    })
+
+    try {
+      await getUserBookingsController(req, res)
+    } catch (e) {
+      const exception = e as HttpException
+      expect(exception).toBeInstanceOf(HttpException)
+      expect(exception.status).toBe(HttpCode.BadRequest)
+      expect(exception.message).toMatch(/Query missing userId/i)
+    }
+  })
+
+  test('should return user bookings when userId is provided', async () => {
+    const { res } = getMockRes()
+    const req = getMockReq<Request>({
+      query: { userId: '1' },
+    })
+
+    // Mock the behavior of the getUserBookings service
+    const mockBookings = [generateRandomBooking(), generateRandomBooking()]
+    jest.mocked(getUserBookings).mockResolvedValue(mockBookings)
+
+    await getUserBookingsController(req, res)
+
+    expect(getUserBookings).toHaveBeenCalledWith(1)
+    expect(res.json).toHaveBeenCalledWith(mockBookings)
+  })
+})

--- a/src/controllers/booking/list.test.ts
+++ b/src/controllers/booking/list.test.ts
@@ -1,8 +1,7 @@
-import { Request, Response } from 'express'
+import { Request } from 'express'
 import { HttpCode, HttpException } from '../../exceptions/HttpException'
 import { listBookings, getUserBookingsController } from './list'
 import { getMockReq, getMockRes } from '@jest-mock/express'
-import * as Policy from '../../policy'
 import { generateRandomBooking } from '../../services/test/utils'
 import { getAllBookings, getUserBookings } from '../../services/bookings'
 

--- a/src/controllers/booking/list.ts
+++ b/src/controllers/booking/list.ts
@@ -1,3 +1,4 @@
+import { Booking } from '@prisma/client'
 import { Response, Request } from 'express'
 import { HttpCode, HttpException } from '@exceptions/HttpException'
 import { getAllBookings, getUserBookings } from '@services/bookings'
@@ -5,6 +6,12 @@ import * as Policy from '@/policy'
 
 const listBookingsAction = 'list bookings'
 
+/**
+ * List all {@link Booking} within a given date range.
+ *
+ * A date range is valid if the start and end dates are valid ISO date strings.
+ * The start date can be after the end date, in which case the response will be an empty array.
+ */
 export async function listBookings(req: Request, res: Response): Promise<void> {
   // Responsibility of frontend to return valid ISO datetime string
   const start = new Date(req.query.start as string)

--- a/src/controllers/booking/update.test.ts
+++ b/src/controllers/booking/update.test.ts
@@ -1,0 +1,287 @@
+import { updateBooking } from '../../services/bookings'
+import { getMockReq, getMockRes } from '@jest-mock/express'
+import * as Policy from '../../policy'
+import { RequestWithUser } from '../../interfaces/auth.interface'
+import {
+  HttpCode,
+  HttpException,
+  UnauthorizedException,
+} from '../../exceptions/'
+import { editBooking } from '.'
+import {
+  generateRandomAbility,
+  generateRandomBooking,
+  generateRandomOrganisation,
+  generateRandomRole,
+  generateRandomUser,
+  generateRandomVenue,
+} from '../../services/test/utils'
+import {
+  getUserAbilities,
+  getUserOrgs,
+  getUserRoles,
+} from '../../services/users'
+import { checkStackedBookings } from '../../middlewares/checks'
+
+jest.mock('../../middlewares/checks', () => ({
+  checkStackedBookings: jest.fn(),
+}))
+
+jest.mock('../../services/users', () => ({
+  getUserAbilities: jest.fn(),
+  getUserRoles: jest.fn(),
+  getUserOrgs: jest.fn(),
+}))
+
+jest.mock('../../services/bookings', () => ({
+  updateBooking: jest.fn(),
+}))
+
+afterEach(() => {
+  jest.resetAllMocks()
+})
+
+describe('editBooking', () => {
+  const bookingAdmin = generateRandomUser()
+  const memberUser = generateRandomUser({ id: 1 })
+  const bookingAdminOrg = generateRandomOrganisation()
+  const memberOrg = generateRandomOrganisation({ id: 1 })
+  const venue = generateRandomVenue()
+
+  const thirtyMinutesLater = new Date()
+  thirtyMinutesLater.setMinutes(thirtyMinutesLater.getMinutes() + 30)
+  const oneHourLater = new Date()
+  oneHourLater.setHours(oneHourLater.getHours() + 1)
+
+  const bookingBody = {
+    start: thirtyMinutesLater,
+    end: oneHourLater,
+    eventName: 'test',
+    venueId: venue.id,
+    userId: memberUser.id,
+    userOrgId: memberOrg.id,
+    orgId: memberOrg.id,
+  }
+
+  test('Should throw HttpException if booking id is invalid number', async () => {
+    const { res } = getMockRes()
+    const req = getMockReq<RequestWithUser>({
+      body: {
+        ...bookingBody,
+      },
+      params: {
+        id: 'invalid',
+      },
+    })
+
+    try {
+      await editBooking(req, res)
+      throw new Error('Should not reach here')
+    } catch (e) {
+      const exception = e as HttpException
+      expect(exception).toBeInstanceOf(HttpException)
+      expect(exception.status).toBe(HttpCode.BadRequest)
+      expect(exception.message).toMatch(/Invalid booking id/i)
+    }
+  })
+
+  describe('User is not logged in', () => {
+    test('Should throw UnauthorizedException', async () => {
+      const { res } = getMockRes()
+      const req = getMockReq<RequestWithUser>({
+        body: {
+          ...bookingBody,
+        },
+        params: {
+          id: '1',
+        },
+      })
+
+      try {
+        await editBooking(req, res)
+        throw new Error('Should not reach here')
+      } catch (e) {
+        const exception = e as HttpException
+        expect(exception).toBeInstanceOf(HttpException)
+        expect(exception.status).toBe(HttpCode.Unauthorized)
+        expect(exception.message).toMatch(/Requires authentication/i)
+      }
+    })
+  })
+
+  // TODO: Handle case for allowing random people to book
+  describe('User is member', () => {
+    test('Should throw UnauthorizedException', async () => {
+      const { res } = getMockRes()
+
+      const req = getMockReq<RequestWithUser>({
+        user: memberUser,
+        body: {
+          ...bookingBody,
+        },
+        params: {
+          id: '1',
+        },
+      })
+
+      // A member role should have no abilities with regards to booking module
+      jest.mocked(getUserAbilities).mockResolvedValue([])
+      jest.mocked(getUserRoles).mockResolvedValue([])
+      jest.mocked(getUserOrgs).mockResolvedValue([])
+
+      try {
+        await editBooking(req, res)
+        throw new Error('Should not reach here')
+      } catch (e) {
+        const exception = e as UnauthorizedException
+        expect(exception).toBeInstanceOf(UnauthorizedException)
+        expect(exception.status).toBe(HttpCode.Unauthorized)
+        expect(exception.message).toMatch(
+          /You are not authorized .* canUpdateBooking/i
+        )
+      }
+    })
+  })
+
+  describe('User is org head', () => {
+    test('Should throw UnauthorizedException if edit other org booking', async () => {
+      const { res } = getMockRes()
+
+      const req = getMockReq<RequestWithUser>({
+        user: memberUser,
+        body: {
+          ...bookingBody,
+        },
+        params: {
+          id: '1',
+        },
+      })
+
+      jest.mocked(getUserAbilities).mockResolvedValue([])
+      jest
+        .mocked(getUserRoles)
+        .mockResolvedValue([generateRandomRole(Policy.OrganisationHeadRole)])
+
+      // Generate random org that the user is not a head of
+      jest
+        .mocked(getUserOrgs)
+        .mockResolvedValue([generateRandomOrganisation({ id: 200 })])
+
+      try {
+        await editBooking(req, res)
+        throw new Error('Should not reach here')
+      } catch (e) {
+        const exception = e as UnauthorizedException
+        expect(exception).toBeInstanceOf(UnauthorizedException)
+        expect(exception.status).toBe(HttpCode.Unauthorized)
+        expect(exception.message).toMatch(
+          /You are not authorized .* canUpdateBooking/i
+        )
+      }
+    })
+
+    test('Should throw HttpException if booking does not exist', async () => {
+      const { res } = getMockRes()
+
+      const req = getMockReq<RequestWithUser>({
+        user: memberUser,
+        body: {
+          ...bookingBody,
+        },
+        params: {
+          id: '1',
+        },
+      })
+
+      jest.mocked(getUserAbilities).mockResolvedValue([])
+      jest
+        .mocked(getUserRoles)
+        .mockResolvedValue([generateRandomRole(Policy.OrganisationHeadRole)])
+      jest.mocked(getUserOrgs).mockResolvedValue([memberOrg])
+
+      jest.mocked(checkStackedBookings).mockResolvedValue(true)
+
+      // Mock that the booking does not exist
+      const errorMessage = `Could not find booking with id 1`
+      jest
+        .mocked(updateBooking)
+        .mockRejectedValue(new HttpException(errorMessage, HttpCode.BadRequest))
+
+      try {
+        await editBooking(req, res)
+        throw new Error('Should not reach here')
+      } catch (e) {
+        console.log(e)
+        expect(e).toBeInstanceOf(HttpException)
+        const exception = e as HttpException
+        expect(exception.status).toBe(HttpCode.BadRequest)
+        expect(exception.message).toMatch(errorMessage)
+      }
+    })
+
+    test('Should successfully update own org booking', async () => {
+      const { res } = getMockRes()
+
+      const req = getMockReq<RequestWithUser>({
+        user: memberUser,
+        body: {
+          ...bookingBody,
+        },
+        params: {
+          id: '1',
+        },
+      })
+
+      jest.mocked(getUserAbilities).mockResolvedValue([])
+      jest
+        .mocked(getUserRoles)
+        .mockResolvedValue([generateRandomRole(Policy.OrganisationHeadRole)])
+      jest.mocked(getUserOrgs).mockResolvedValue([memberOrg])
+
+      jest.mocked(checkStackedBookings).mockResolvedValue(true)
+
+      const mockBooking = generateRandomBooking({
+        id: 1,
+        userId: memberUser.id,
+      })
+      jest.mocked(updateBooking).mockResolvedValue(mockBooking)
+
+      await editBooking(req, res)
+      expect(res.json).toBeCalledWith({ result: [mockBooking] })
+    })
+  })
+
+  describe('User is admin', () => {
+    test('Should successfully update booking', async () => {
+      const { res } = getMockRes()
+
+      const req = getMockReq<RequestWithUser>({
+        user: memberUser,
+        body: {
+          ...bookingBody,
+        },
+        params: {
+          id: '1',
+        },
+      })
+
+      jest
+        .mocked(getUserAbilities)
+        .mockResolvedValue([
+          generateRandomAbility(Policy.canUpdateBookingAbility),
+        ])
+      jest.mocked(getUserRoles).mockResolvedValue([])
+      jest.mocked(getUserOrgs).mockResolvedValue([])
+      jest.mocked(checkStackedBookings).mockResolvedValue(true)
+
+      const mockBooking = generateRandomBooking({
+        id: 1,
+        userId: memberUser.id,
+      })
+      jest.mocked(updateBooking).mockResolvedValue(mockBooking)
+
+      await editBooking(req, res)
+      expect(res.json).toBeCalledWith({ result: [mockBooking] })
+    })
+  })
+})

--- a/src/controllers/booking/update.ts
+++ b/src/controllers/booking/update.ts
@@ -13,7 +13,7 @@ export async function editBooking(
 ): Promise<void> {
   const bookingId = parseInt(req.params['id'], 10)
   if (Number.isNaN(bookingId)) {
-    throw new HttpException('Booking id not found', HttpCode.BadRequest)
+    throw new HttpException('Invalid booking id', HttpCode.BadRequest)
   }
   if (!req.user) {
     throw new HttpException('Requires authentication', HttpCode.Unauthorized)
@@ -35,6 +35,6 @@ export async function editBooking(
     req.user
   )
 
-  const updatedBooking = await updateBooking(bookingId, bookingPayload, userId)
+  const updatedBooking = await updateBooking(bookingId, bookingPayload)
   res.status(200).json({ result: [updatedBooking] })
 }

--- a/src/exceptions/HttpException.ts
+++ b/src/exceptions/HttpException.ts
@@ -1,4 +1,5 @@
 export enum HttpCode {
+  OK = 200,
   BadRequest = 400,
   Unauthorized = 401,
   Forbidden = 403,

--- a/src/policy/bookingpolicies/policy.ts
+++ b/src/policy/bookingpolicies/policy.ts
@@ -31,9 +31,20 @@ export const createBookingPolicy = (booking: BookingPayload) => {
   )
 }
 
-export const deleteBookingPolicy = () => {
+/**
+ * Creates a policy to delete a booking.
+ * Bookings can only be deleted by the user who created them or by an admin.
+ *
+ * @param booking {@link BookingPayload}
+ * @param user {@link User}
+ */
+export const deleteBookingPolicy = (booking: BookingPayload, user: User) => {
   return new Policies.Any(
-    new Policies.HasAnyAbilities(Abilities.canDeleteBooking)
+    new Policies.HasAnyAbilities(Abilities.canDeleteBooking),
+    new Policies.All(
+      new Policies.BelongToOrg(booking.userOrgId),
+      new AllowIfBookingBelongToUser(booking, user)
+    )
   )
 }
 

--- a/src/policy/commonpolicies/all.test.ts
+++ b/src/policy/commonpolicies/all.test.ts
@@ -1,0 +1,28 @@
+import { Policy } from '../../interfaces/policy.interface'
+import { All } from './all'
+import { Allow } from './allow'
+import { Deny } from './deny'
+
+describe('All Policy', () => {
+  let mockPolicies: Policy[]
+
+  beforeEach(() => {
+    mockPolicies = [new Allow(), new Allow()]
+  })
+
+  test('should allow if all policies allow', async () => {
+    const policy = new All(...mockPolicies)
+    const result = await policy.Validate()
+
+    expect(result).toEqual('allow')
+    expect(policy.Reason()).toEqual('')
+  })
+
+  test('should deny if any policy denies', async () => {
+    const policy = new All(...[new Allow(), new Deny()])
+    const result = await policy.Validate()
+
+    expect(result).toEqual('deny')
+    expect(policy.Reason()).toMatch(/Denied/)
+  })
+})

--- a/src/policy/commonpolicies/allow.test.ts
+++ b/src/policy/commonpolicies/allow.test.ts
@@ -1,0 +1,18 @@
+import { Allow } from './allow'
+
+describe('Allow Policy', () => {
+  let policy: Allow
+
+  beforeEach(() => {
+    policy = new Allow()
+  })
+
+  test('should always return allow', async () => {
+    const result = await policy.Validate()
+    expect(result).toEqual('allow')
+  })
+
+  test('should return the correct reason', () => {
+    expect(policy.Reason()).toEqual('Allowed.')
+  })
+})

--- a/src/policy/commonpolicies/any.test.ts
+++ b/src/policy/commonpolicies/any.test.ts
@@ -1,0 +1,28 @@
+import { Policy } from '../../interfaces/policy.interface'
+import { Any } from './any'
+import { Allow } from './allow'
+import { Deny } from './deny'
+
+describe('Any Policy', () => {
+  let mockPolicies: Policy[]
+
+  beforeEach(() => {
+    mockPolicies = [new Allow(), new Deny()]
+  })
+
+  test('should allow if any policy allows', async () => {
+    const policy = new Any(...mockPolicies)
+    const result = await policy.Validate()
+
+    expect(result).toEqual('allow')
+    expect(policy.Reason()).toEqual('')
+  })
+
+  test('should deny if all policies deny', async () => {
+    const policy = new Any(...[new Deny(), new Deny()])
+    const result = await policy.Validate()
+
+    expect(result).toEqual('deny')
+    expect(policy.Reason()).toMatch(/Denied/)
+  })
+})

--- a/src/policy/commonpolicies/belongToOrg.test.ts
+++ b/src/policy/commonpolicies/belongToOrg.test.ts
@@ -1,0 +1,54 @@
+import * as Policy from '../../policy'
+import { BelongToOrg } from './belongToOrg'
+import { getUserOrgs } from '../../services/users'
+import {
+  generateRandomUser,
+  generateRandomOrganisation,
+} from '../../services/test/utils'
+
+jest.mock('@/services/users', () => ({
+  getUserOrgs: jest.fn(),
+}))
+
+describe('BelongToOrg Policy', () => {
+  const mockUser = generateRandomUser({ id: 1 })
+  const mockOrg = generateRandomOrganisation({ id: 1 })
+  const orgId = mockOrg.id
+
+  // Reset the mock before each test to ensure isolation
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  test('should deny if user is not logged in', async () => {
+    const policy = new BelongToOrg(orgId)
+    const result = await policy.Validate()
+
+    expect(result).toEqual('deny')
+    expect(policy.Reason()).toEqual('User is not logged in')
+  })
+
+  test('should allow if user belongs to the specified organization', async () => {
+    jest.mocked(getUserOrgs).mockResolvedValue([mockOrg])
+
+    const policy = new BelongToOrg(orgId)
+    const result = await policy.Validate(mockUser)
+
+    expect(result).toEqual('allow')
+    expect(policy.Reason()).toEqual('')
+  })
+
+  test('should deny if user does not belong to the specified organization', async () => {
+    jest
+      .mocked(getUserOrgs)
+      .mockResolvedValue([generateRandomOrganisation({ id: 2 })])
+
+    const policy = new BelongToOrg(orgId)
+    const result = await policy.Validate(mockUser)
+
+    expect(result).toEqual('deny')
+    expect(policy.Reason()).toContain(
+      `User does not belong to org id - ${orgId}`
+    )
+  })
+})

--- a/src/policy/commonpolicies/deny.test.ts
+++ b/src/policy/commonpolicies/deny.test.ts
@@ -1,0 +1,18 @@
+import { Deny } from './deny'
+
+describe('Deny Policy', () => {
+  let policy: Deny
+
+  beforeEach(() => {
+    policy = new Deny()
+  })
+
+  test('should always return deny', async () => {
+    const result = await policy.Validate()
+    expect(result).toEqual('deny')
+  })
+
+  test('should return the correct reason', () => {
+    expect(policy.Reason()).toEqual('Denied. Only admin is allowed to perform this action.')
+  })
+})

--- a/src/policy/commonpolicies/hasAllAbilities.test.ts
+++ b/src/policy/commonpolicies/hasAllAbilities.test.ts
@@ -1,0 +1,53 @@
+import * as Policy from '../../policy'
+import { HasAllAbilities } from '.'
+import { getUserAbilities } from '../../services/users'
+import {
+  generateRandomAbility,
+  generateRandomUser,
+} from '../../services/test/utils'
+
+jest.mock('@/services/users', () => ({
+  getUserAbilities: jest.fn(),
+}))
+
+describe('HasAllAbilities Policy', () => {
+  const mockUser = generateRandomUser({ id: 1 })
+  const abilities = [
+    generateRandomAbility(Policy.canUpdateBookingAbility),
+    generateRandomAbility(Policy.canDeleteBookingAbility),
+  ]
+  const abilityNames = abilities.map((a) => a.name)
+
+  // Reset the mock before each test to ensure isolation
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  test('should deny if user is not logged in', async () => {
+    const policy = new HasAllAbilities(...abilityNames)
+    const result = await policy.Validate()
+
+    expect(result).toEqual('deny')
+    expect(policy.Reason()).toEqual('User is not logged in')
+  })
+
+  test('should allow if user has all abilities', async () => {
+    jest.mocked(getUserAbilities).mockResolvedValue(abilities)
+
+    const policy = new HasAllAbilities(...abilityNames)
+    const result = await policy.Validate(mockUser)
+
+    expect(result).toEqual('allow')
+    expect(policy.Reason()).toEqual('')
+  })
+
+  test('should deny if user lacks one or more abilities', async () => {
+    jest.mocked(getUserAbilities).mockResolvedValue([abilities[0]])
+
+    const policy = new HasAllAbilities(...abilityNames)
+    const result = await policy.Validate(mockUser)
+
+    expect(result).toEqual('deny')
+    expect(policy.Reason()).toContain('User does not have the ability')
+  })
+})

--- a/src/policy/commonpolicies/hasAllAbilities.ts
+++ b/src/policy/commonpolicies/hasAllAbilities.ts
@@ -4,11 +4,11 @@ import { User } from '@prisma/client'
 import { ToAbilitiesMap } from './util'
 
 export class HasAllAbilities implements Policy {
-  private abilities: AbilityName[]
+  private abilityNames: AbilityName[]
   private reason: string = ''
 
-  constructor(...abilities: AbilityName[]) {
-    this.abilities = abilities
+  constructor(...abilityNames: AbilityName[]) {
+    this.abilityNames = abilityNames
   }
 
   public Validate = async (u?: User): Promise<Decision> => {
@@ -20,9 +20,9 @@ export class HasAllAbilities implements Policy {
     const abilities = await getUserAbilities(u.id)
     const abilitiesMap = ToAbilitiesMap(abilities)
 
-    for (const ability of this.abilities) {
-      if (!abilitiesMap.get(ability)) {
-        this.reason = `User does not have the ability: ${ability}.`
+    for (const name of this.abilityNames) {
+      if (!abilitiesMap.get(name)) {
+        this.reason = `User does not have the ability: ${name}.`
         return 'deny'
       }
     }

--- a/src/policy/commonpolicies/hasAnyAbilities.test.ts
+++ b/src/policy/commonpolicies/hasAnyAbilities.test.ts
@@ -1,0 +1,53 @@
+import * as Policy from '../../policy'
+import { HasAnyAbilities } from '.'
+import { getUserAbilities } from '../../services/users'
+import {
+  generateRandomAbility,
+  generateRandomUser,
+} from '../../services/test/utils'
+
+jest.mock('@/services/users', () => ({
+  getUserAbilities: jest.fn(),
+}))
+
+describe('HasAnyAbilities Policy', () => {
+  const mockUser = generateRandomUser({ id: 1 })
+  const abilities = [
+    generateRandomAbility(Policy.canUpdateBookingAbility),
+    generateRandomAbility(Policy.canDeleteBookingAbility),
+  ]
+  const abilityNames = abilities.map((a) => a.name)
+
+  // Reset the mock before each test to ensure isolation
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  test('should deny if user is not logged in', async () => {
+    const policy = new HasAnyAbilities(...abilityNames)
+    const result = await policy.Validate()
+
+    expect(result).toEqual('deny')
+    expect(policy.Reason()).toEqual('User is not logged in')
+  })
+
+  test('should allow if user has any ability', async () => {
+    jest.mocked(getUserAbilities).mockResolvedValue([abilities[0]])
+
+    const policy = new HasAnyAbilities(...abilityNames)
+    const result = await policy.Validate(mockUser)
+
+    expect(result).toEqual('allow')
+    expect(policy.Reason()).toEqual('')
+  })
+
+  test('should deny if user has none of the abilities', async () => {
+    jest.mocked(getUserAbilities).mockResolvedValue([])
+
+    const policy = new HasAnyAbilities(...abilityNames)
+    const result = await policy.Validate(mockUser)
+
+    expect(result).toEqual('deny')
+    expect(policy.Reason()).toContain('User does not have any of the abilities')
+  })
+})

--- a/src/policy/commonpolicies/hasAnyAbilities.ts
+++ b/src/policy/commonpolicies/hasAnyAbilities.ts
@@ -4,11 +4,11 @@ import { User } from '@prisma/client'
 import { ToAbilitiesMap } from './util'
 
 export class HasAnyAbilities implements Policy {
-  private abilities: AbilityName[]
+  private abilityNames: AbilityName[]
   private reason: string = ''
 
-  constructor(...abilities: AbilityName[]) {
-    this.abilities = abilities
+  constructor(...abilityNames: AbilityName[]) {
+    this.abilityNames = abilityNames
   }
 
   public Validate = async (u?: User): Promise<Decision> => {
@@ -20,13 +20,13 @@ export class HasAnyAbilities implements Policy {
     const abilities = await getUserAbilities(u.id)
     const abilitiesMap = ToAbilitiesMap(abilities)
 
-    for (const ability of this.abilities) {
-      if (abilitiesMap.get(ability)) {
+    for (const name of this.abilityNames) {
+      if (abilitiesMap.get(name)) {
         return 'allow'
       }
     }
 
-    this.reason = `User does not have any of the abilities: ${this.abilities.join(
+    this.reason = `User does not have any of the abilities: ${this.abilityNames.join(
       ', '
     )}.`
 

--- a/src/policy/commonpolicies/hasRole.test.ts
+++ b/src/policy/commonpolicies/hasRole.test.ts
@@ -1,0 +1,52 @@
+import * as Policy from '../../policy'
+import { HasRole } from './hasRole'
+import { getUserRoles } from '../../services/users'
+import {
+  generateRandomUser,
+  generateRandomRole,
+} from '../../services/test/utils'
+
+jest.mock('../../services/users', () => ({
+  getUserRoles: jest.fn(),
+}))
+
+describe('HasRole Policy', () => {
+  const mockUser = generateRandomUser({ id: 1 })
+  const mockRole = generateRandomRole(Policy.MemberRole)
+  const roleName = mockRole.name
+
+  // Reset the mock before each test to ensure isolation
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  test('should deny if user is not logged in', async () => {
+    const policy = new HasRole(roleName)
+    const result = await policy.Validate()
+
+    expect(result).toEqual('deny')
+    expect(policy.Reason()).toEqual('User is not logged in')
+  })
+
+  test('should allow if user has the specified role', async () => {
+    jest.mocked(getUserRoles).mockResolvedValue([mockRole])
+
+    const policy = new HasRole(roleName)
+    const result = await policy.Validate(mockUser)
+
+    expect(result).toEqual('allow')
+    expect(policy.Reason()).toEqual('')
+  })
+
+  test('should deny if user lacks the specified role', async () => {
+    jest
+      .mocked(getUserRoles)
+      .mockResolvedValue([generateRandomRole(Policy.SpacesAdminRole)])
+
+    const policy = new HasRole(roleName)
+    const result = await policy.Validate(mockUser)
+
+    expect(result).toEqual('deny')
+    expect(policy.Reason()).toContain(`User does not have role ${roleName}`)
+  })
+})

--- a/src/services/bookings.ts
+++ b/src/services/bookings.ts
@@ -163,10 +163,9 @@ export async function addBooking(booking: BookingPayload): Promise<Booking> {
  */
 export async function updateBooking(
   bookingId: Booking['id'],
-  updatedBooking: BookingPayload,
-  userId: Booking['userId']
+  updatedBooking: BookingPayload
 ): Promise<Booking> {
-  const bookingToUpdate = await prisma.booking.findUniqueOrThrow({
+  const bookingToUpdate = await prisma.booking.findUnique({
     where: {
       id: bookingId,
     },

--- a/src/services/test/utils.ts
+++ b/src/services/test/utils.ts
@@ -41,7 +41,7 @@ export function generateRandomVenue(): Venue {
   }
 }
 
-export function generateRandomUser(): User {
+export function generateRandomUser(user?: Partial<User>): User {
   return {
     id: generateRandomTableId(),
     name: faker.name.firstName(),
@@ -49,10 +49,13 @@ export function generateRandomUser(): User {
     telegramId: faker.datatype.number().toString(),
     telegramDpUrl: faker.internet.url(),
     deleted: false,
+    ...user,
   }
 }
 
-export function generateRandomOrganisation(): Organisation {
+export function generateRandomOrganisation(
+  org?: Partial<Organisation>
+): Organisation {
   return {
     id: generateRandomTableId(),
     name: faker.company.name(),
@@ -63,6 +66,7 @@ export function generateRandomOrganisation(): Organisation {
     category: generateRandomIgCategory(),
     isInactive: false,
     isInvisible: false,
+    ...org,
   }
 }
 

--- a/src/services/test/utils.ts
+++ b/src/services/test/utils.ts
@@ -19,7 +19,7 @@ function generateRandomIgCategory() {
 const generateRandomTableId: () => number = () =>
   faker.datatype.number({ min: 1 })
 
-export function generateRandomBooking(booking: Partial<Booking>): Booking {
+export function generateRandomBooking(booking?: Partial<Booking>): Booking {
   return {
     id: generateRandomTableId(),
     eventName: faker.lorem.words(),


### PR DESCRIPTION
Fixes #88 
Fixes #89 
Fixes #90 
Fixes #91 

- chore: add test watch script
- feat: update delete booking to check if user made booking
- feat: add OK status code
- chore: update jest config to ignore interface
- feat: update generateRandom utils for partial
- test: add tests for delete booking
- feat: change partial booking data to optional
- test: add test for list bookings
- fix: throw HttpException instead of PrismaError
- test: add test for update booking
- refactor: change abilities to abilityNames
- test: add tests for common policies
