### PR TITLE
test: add unit tests for user controller

### DIFF
--- a/src/controllers/user/create.test.ts
+++ b/src/controllers/user/create.test.ts
@@ -1,0 +1,114 @@
+import { getMockReq, getMockRes } from '@jest-mock/express'
+import * as Policy from '../../policy'
+import { RequestWithUser } from '../../interfaces/auth.interface'
+import { HttpCode, HttpException } from '../../exceptions/HttpException'
+import { addUser, getUserAbilities } from '../../services/users'
+import { createUser } from './create'
+import {
+  generateRandomAbility,
+  generateRandomUser,
+} from '../../services/test/utils'
+import { UnauthorizedException } from '../../exceptions'
+
+jest.mock('../../services/users', () => ({
+  addUser: jest.fn(),
+  getUserAbilities: jest.fn(),
+  getUserRoles: jest.fn(),
+  getUserOrgs: jest.fn(),
+}))
+
+describe('Create User controller', () => {
+  const userMember = generateRandomUser({ id: 1 })
+  const mockNewUser = {
+    name: 'test',
+    telegramUserName: 'test',
+    telegramId: 'test',
+  }
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  test('Should return 401 not authorized if user is not logged in', async () => {
+    const { res } = getMockRes()
+    const req = getMockReq<RequestWithUser>()
+
+    try {
+      await createUser(req, res)
+      throw new Error('Test failed')
+    } catch (e) {
+      expect(e).toBeInstanceOf(HttpException)
+      const exception = e as HttpException
+      expect(exception.status).toBe(HttpCode.Unauthorized)
+      expect(exception.message).toMatch(/Requires authentication/)
+    }
+  })
+
+  test('Should return 401 not authorized if user is not an admin', async () => {
+    const { res } = getMockRes()
+    const req = getMockReq<RequestWithUser>({
+      user: userMember,
+      body: mockNewUser,
+    })
+
+    jest.mocked(getUserAbilities).mockResolvedValue([])
+
+    try {
+      await createUser(req, res)
+      throw new Error('Test failed')
+    } catch (e) {
+      expect(e).toBeInstanceOf(UnauthorizedException)
+      const exception = e as UnauthorizedException
+      expect(exception.status).toBe(HttpCode.Unauthorized)
+      expect(exception.message).toMatch(/You are not authorized to/)
+    }
+  })
+
+  describe('User is admin', () => {
+    test('Should throw 400 Bad Request if body does not match user schema', async () => {
+      const mockNewUserBadData = {
+        name: 'test',
+        oops: 'test',
+        telegramId: 'test',
+      }
+
+      const { res } = getMockRes()
+      const req = getMockReq<RequestWithUser>({
+        user: userMember,
+        body: mockNewUserBadData,
+      })
+
+      try {
+        await createUser(req, res)
+        throw new Error('Test failed')
+      } catch (e) {
+        expect(e).toBeInstanceOf(UnauthorizedException)
+        const exception = e as UnauthorizedException
+        expect(exception.status).toBe(HttpCode.Unauthorized)
+        expect(exception.message).toMatch(/Invalid new user data/)
+        expect(getUserAbilities).not.toHaveBeenCalled()
+      }
+    })
+
+    test('Should return 200 if data is valid', async () => {
+      const insertedUser = generateRandomUser(mockNewUser)
+
+      const { res } = getMockRes()
+      const req = getMockReq<RequestWithUser>({
+        user: userMember,
+        body: mockNewUser,
+      })
+
+      jest
+        .mocked(getUserAbilities)
+        .mockResolvedValue([generateRandomAbility(Policy.canManageAllAbility)])
+      jest.mocked(addUser).mockResolvedValue(insertedUser)
+
+      await createUser(req, res)
+
+      expect(addUser).toHaveBeenCalledWith(mockNewUser)
+      expect(res.status).toHaveBeenCalledWith(200)
+      expect(res.json).toHaveBeenCalledWith({ result: [insertedUser] })
+    })
+  })
+})

--- a/src/controllers/user/create.test.ts
+++ b/src/controllers/user/create.test.ts
@@ -82,9 +82,9 @@ describe('Create User controller', () => {
         await createUser(req, res)
         throw new Error('Test failed')
       } catch (e) {
-        expect(e).toBeInstanceOf(UnauthorizedException)
-        const exception = e as UnauthorizedException
-        expect(exception.status).toBe(HttpCode.Unauthorized)
+        expect(e).toBeInstanceOf(HttpException)
+        const exception = e as HttpException
+        expect(exception.status).toBe(HttpCode.BadRequest)
         expect(exception.message).toMatch(/Invalid new user data/)
         expect(getUserAbilities).not.toHaveBeenCalled()
       }

--- a/src/controllers/user/create.ts
+++ b/src/controllers/user/create.ts
@@ -19,7 +19,7 @@ export async function createUser(
 
   const newUserRes = UserSchema.safeParse(req.body)
   if (!newUserRes.success) {
-    throw new UnauthorizedException('Invalid new user data')
+    throw new HttpException('Invalid new user data', HttpCode.BadRequest)
   }
 
   await Policy.Authorize(createUserAction, Policy.createUserPolicy(), user)

--- a/src/controllers/user/create.ts
+++ b/src/controllers/user/create.ts
@@ -4,6 +4,7 @@ import { HttpCode, HttpException } from '@exceptions/HttpException'
 import { RequestWithUser } from '@interfaces/auth.interface'
 import { UserSchema } from '@interfaces/user.interface'
 import * as Policy from '@/policy'
+import { UnauthorizedException } from '@/exceptions'
 
 const createUserAction = 'create user'
 
@@ -16,9 +17,14 @@ export async function createUser(
     throw new HttpException('Requires authentication', HttpCode.Unauthorized)
   }
 
+  const newUserRes = UserSchema.safeParse(req.body)
+  if (!newUserRes.success) {
+    throw new UnauthorizedException('Invalid new user data')
+  }
+
   await Policy.Authorize(createUserAction, Policy.createUserPolicy(), user)
 
-  const newUser = UserSchema.parse(req.body)
+  const newUser = newUserRes.data
   const inserted = await addUser(newUser)
   res.status(200).json({ result: [inserted] })
 }

--- a/src/controllers/user/delete.test.ts
+++ b/src/controllers/user/delete.test.ts
@@ -1,0 +1,123 @@
+import { getMockReq, getMockRes } from '@jest-mock/express'
+import * as Policy from '../../policy'
+import { RequestWithUser } from '../../interfaces/auth.interface'
+import { HttpCode, HttpException } from '../../exceptions/HttpException'
+import { destroyUser, getUserAbilities } from '../../services/users'
+import { deleteUser } from './delete'
+import {
+  generateRandomAbility,
+  generateRandomUser,
+} from '../../services/test/utils'
+import { UnauthorizedException } from '../../exceptions'
+
+jest.mock('../../services/users', () => ({
+  destroyUser: jest.fn(),
+  getUserAbilities: jest.fn(),
+  getUserRoles: jest.fn(),
+  getUserOrgs: jest.fn(),
+}))
+
+describe('Delete User controller', () => {
+  const userMember = generateRandomUser({ id: 1 })
+  const userToDeleteStringId = '2'
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  test('Should return 400 bad request if user id is not a number', async () => {
+    const { res } = getMockRes()
+    const req = getMockReq<RequestWithUser>({
+      params: { id: 'hello' },
+      user: userMember,
+    })
+
+    try {
+      await deleteUser(req, res)
+      throw new Error('Test failed')
+    } catch (e) {
+      expect(e).toBeInstanceOf(HttpException)
+      const exception = e as HttpException
+      expect(exception.status).toBe(HttpCode.BadRequest)
+      expect(exception.message).toMatch(/User id not found/)
+    }
+  })
+
+  test('Should return 401 not authorized if user is not logged in', async () => {
+    const { res } = getMockRes()
+    const req = getMockReq<RequestWithUser>({
+      params: { id: userToDeleteStringId },
+    })
+
+    try {
+      await deleteUser(req, res)
+      throw new Error('Test failed')
+    } catch (e) {
+      expect(e).toBeInstanceOf(HttpException)
+      const exception = e as HttpException
+      expect(exception.status).toBe(HttpCode.Unauthorized)
+      expect(exception.message).toMatch(/Requires authentication/)
+    }
+  })
+
+  test('Should return 400 bad request if delete self', async () => {
+    const { res } = getMockRes()
+    const req = getMockReq<RequestWithUser>({
+      params: { id: userMember.id.toString() },
+      user: userMember,
+    })
+
+    try {
+      await deleteUser(req, res)
+      throw new Error('Test failed')
+    } catch (e) {
+      expect(e).toBeInstanceOf(HttpException)
+      const exception = e as HttpException
+      expect(exception.status).toBe(HttpCode.BadRequest)
+      expect(exception.message).toMatch(/Cannot delete self/)
+    }
+  })
+
+  test('Should return 401 not authorized if user is not an admin', async () => {
+    const { res } = getMockRes()
+    const req = getMockReq<RequestWithUser>({
+      params: { id: userToDeleteStringId },
+      user: userMember,
+    })
+
+    jest.mocked(getUserAbilities).mockResolvedValue([])
+
+    try {
+      await deleteUser(req, res)
+      throw new Error('Test failed')
+    } catch (e) {
+      expect(e).toBeInstanceOf(UnauthorizedException)
+      const exception = e as UnauthorizedException
+      expect(exception.status).toBe(HttpCode.Unauthorized)
+      expect(exception.message).toMatch(/You are not authorized to/)
+    }
+  })
+
+  test('Should return 200 and the deleted user', async () => {
+    const userToDeleteId = parseInt(userToDeleteStringId)
+    const mockDeletedUser = generateRandomUser({
+      id: userToDeleteId,
+    })
+    const { res } = getMockRes()
+    const req = getMockReq<RequestWithUser>({
+      params: { id: userToDeleteStringId },
+      user: userMember,
+    })
+
+    jest
+      .mocked(getUserAbilities)
+      .mockResolvedValue([generateRandomAbility(Policy.canManageAllAbility)])
+    jest.mocked(destroyUser).mockResolvedValue(mockDeletedUser)
+
+    await deleteUser(req, res)
+
+    expect(destroyUser).toHaveBeenCalledWith(userToDeleteId)
+    expect(res.status).toHaveBeenCalledWith(200)
+    expect(res.json).toHaveBeenCalledWith(mockDeletedUser)
+  })
+})

--- a/src/controllers/user/delete.ts
+++ b/src/controllers/user/delete.ts
@@ -10,16 +10,21 @@ export async function deleteUser(
   req: RequestWithUser,
   res: Response
 ): Promise<void> {
-  const userToDelete = parseInt(req.params['id'], 10)
-  if (Number.isNaN(userToDelete)) {
+  const userToDeleteId = parseInt(req.params['id'], 10)
+  if (Number.isNaN(userToDeleteId)) {
     throw new HttpException('User id not found', HttpCode.BadRequest)
   }
+
   if (!req.user) {
     throw new HttpException('Requires authentication', HttpCode.Unauthorized)
   }
 
+  if (req.user.id === userToDeleteId) {
+    throw new HttpException('Cannot delete self', HttpCode.BadRequest)
+  }
+
   await Policy.Authorize(deleteUserAction, Policy.deleteUserPolicy(), req.user)
 
-  const user = await destroyUser(userToDelete)
+  const user = await destroyUser(userToDeleteId)
   res.status(200).json(user)
 }

--- a/src/controllers/user/list.test.ts
+++ b/src/controllers/user/list.test.ts
@@ -1,0 +1,47 @@
+import { getMockReq, getMockRes } from '@jest-mock/express'
+import { RequestWithUser } from '../../interfaces/auth.interface'
+import { HttpCode, HttpException } from '../../exceptions/HttpException'
+import { getAllUsers, getUserAbilities } from '../../services/users'
+import { listUser } from './list'
+import { generateRandomUser } from '../../services/test/utils'
+
+jest.mock('../../services/users', () => ({
+  getAllUsers: jest.fn(),
+  getUserAbilities: jest.fn(),
+  getUserRoles: jest.fn(),
+  getUserOrgs: jest.fn(),
+}))
+
+describe('List User controller', () => {
+  const userMember = generateRandomUser({ id: 1 })
+
+  test('Should return 401 not authorized if user is not logged in', async () => {
+    const { res } = getMockRes()
+    const req = getMockReq<RequestWithUser>()
+
+    try {
+      await listUser(req, res)
+      throw new Error('Test failed')
+    } catch (e) {
+      expect(e).toBeInstanceOf(HttpException)
+      const exception = e as HttpException
+      expect(exception.status).toBe(HttpCode.Unauthorized)
+      expect(exception.message).toMatch(/Requires authentication/)
+    }
+  })
+
+  test('Should return 200 and list of users if user is logged in', async () => {
+    const { res } = getMockRes()
+    const req = getMockReq<RequestWithUser>({
+      user: userMember,
+    })
+
+    const users = [generateRandomUser({ id: 1 }), generateRandomUser({ id: 2 })]
+
+    jest.mocked(getUserAbilities).mockResolvedValue([])
+    jest.mocked(getAllUsers).mockResolvedValue(users)
+
+    await listUser(req, res)
+    expect(res.json).toBeCalledWith(users)
+  })
+})

--- a/src/controllers/user/list.ts
+++ b/src/controllers/user/list.ts
@@ -14,8 +14,7 @@ const listUserAction = 'list user'
  */
 export async function listUser(
   req: RequestWithUser,
-  res: Response,
-  next: NextFunction
+  res: Response
 ): Promise<void> {
   const user = req.user
   if (!user) {

--- a/src/controllers/user/update.test.ts
+++ b/src/controllers/user/update.test.ts
@@ -1,0 +1,145 @@
+import { getMockReq, getMockRes } from '@jest-mock/express'
+import * as Policy from '../../policy'
+import { RequestWithUser } from '../../interfaces/auth.interface'
+import { HttpCode, HttpException } from '../../exceptions/HttpException'
+import { getUserAbilities, updateUser } from '../../services/users'
+import { editUser } from './update'
+import {
+  generateRandomAbility,
+  generateRandomUser,
+} from '../../services/test/utils'
+import { UnauthorizedException } from '../../exceptions'
+
+jest.mock('../../services/users', () => ({
+  updateUser: jest.fn(),
+  getUserAbilities: jest.fn(),
+  getUserRoles: jest.fn(),
+  getUserOrgs: jest.fn(),
+}))
+
+describe('Create User controller', () => {
+  const userMember = generateRandomUser({ id: 1 })
+
+  const updateUserStringId = '2'
+  const updateUserPayload = {
+    name: 'test',
+    telegramUserName: 'test',
+    telegramId: 'test',
+  }
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  test('Should return 400 Bad Request if user id is not a number', async () => {
+    const { res } = getMockRes()
+    const req = getMockReq<RequestWithUser>({
+      user: userMember,
+      body: updateUserPayload,
+      params: { id: 'not a number' },
+    })
+
+    try {
+      await editUser(req, res)
+      throw new Error('Test failed')
+    } catch (e) {
+      expect(e).toBeInstanceOf(HttpException)
+      const exception = e as HttpException
+      expect(exception.status).toBe(HttpCode.BadRequest)
+      expect(exception.message).toMatch(/User id is not a number/)
+    }
+  })
+
+  test('Should return 401 not authorized if user is not logged in', async () => {
+    const { res } = getMockRes()
+    const req = getMockReq<RequestWithUser>({
+      body: updateUserPayload,
+      params: { id: updateUserStringId },
+    })
+
+    try {
+      await editUser(req, res)
+      throw new Error('Test failed')
+    } catch (e) {
+      expect(e).toBeInstanceOf(HttpException)
+      const exception = e as HttpException
+      expect(exception.status).toBe(HttpCode.Unauthorized)
+      expect(exception.message).toMatch(/Requires authentication/)
+    }
+  })
+
+  test('Should return 401 not authorized if user is not an admin', async () => {
+    const { res } = getMockRes()
+    const req = getMockReq<RequestWithUser>({
+      user: userMember,
+      body: updateUserPayload,
+      params: { id: updateUserStringId },
+    })
+
+    jest.mocked(getUserAbilities).mockResolvedValue([])
+
+    try {
+      await editUser(req, res)
+      throw new Error('Test failed')
+    } catch (e) {
+      expect(e).toBeInstanceOf(UnauthorizedException)
+      const exception = e as UnauthorizedException
+      expect(exception.status).toBe(HttpCode.Unauthorized)
+      expect(exception.message).toMatch(/You are not authorized to/)
+    }
+  })
+
+  describe('User is admin', () => {
+    test('Should throw 400 Bad Request if body does not match user schema', async () => {
+      const mockNewUserBadData = {
+        name: 'test',
+        oops: 'test',
+        telegramId: 'test',
+      }
+
+      const { res } = getMockRes()
+      const req = getMockReq<RequestWithUser>({
+        user: userMember,
+        body: mockNewUserBadData,
+        params: { id: updateUserStringId },
+      })
+
+      try {
+        await editUser(req, res)
+        throw new Error('Test failed')
+      } catch (e) {
+        expect(e).toBeInstanceOf(HttpException)
+        const exception = e as HttpException
+        expect(exception.status).toBe(HttpCode.BadRequest)
+        expect(exception.message).toMatch(/Invalid user data/)
+        expect(getUserAbilities).not.toHaveBeenCalled()
+      }
+    })
+
+    test('Should return 200 if data is valid', async () => {
+      const updateUserId = parseInt(updateUserStringId, 10)
+      const updatedUser = generateRandomUser({
+        ...updateUserPayload,
+        id: updateUserId,
+      })
+
+      const { res } = getMockRes()
+      const req = getMockReq<RequestWithUser>({
+        user: userMember,
+        body: updateUserPayload,
+        params: { id: updateUserStringId },
+      })
+
+      jest
+        .mocked(getUserAbilities)
+        .mockResolvedValue([generateRandomAbility(Policy.canManageAllAbility)])
+      jest.mocked(updateUser).mockResolvedValue(updatedUser)
+
+      await editUser(req, res)
+
+      expect(updateUser).toHaveBeenCalledWith(updateUserId, updateUserPayload)
+      expect(res.status).toHaveBeenCalledWith(200)
+      expect(res.json).toHaveBeenCalledWith({ result: [updatedUser] })
+    })
+  })
+})

--- a/src/controllers/user/update.ts
+++ b/src/controllers/user/update.ts
@@ -15,14 +15,21 @@ export async function editUser(
   if (Number.isNaN(userToUpdateId)) {
     throw new HttpException('User id is not a number', HttpCode.BadRequest)
   }
-  const adminUser = req.user
-  if (!adminUser) {
+
+  const userToUpdateRes = UserSchema.safeParse(req.body)
+  if (!userToUpdateRes.success) {
+    throw new HttpException('Invalid user data', HttpCode.BadRequest)
+  }
+
+  const userToUpdate = userToUpdateRes.data
+
+  const user = req.user
+  if (!user) {
     throw new HttpException('Requires authentication', HttpCode.Unauthorized)
   }
 
-  await Policy.Authorize(editUserAction, Policy.updateUserPolicy(), adminUser)
+  await Policy.Authorize(editUserAction, Policy.updateUserPolicy(), user)
 
-  const user = UserSchema.parse(req.body)
-  const updatedUser = await updateUser(userToUpdateId, user)
+  const updatedUser = await updateUser(userToUpdateId, userToUpdate)
   res.status(200).json({ result: [updatedUser] })
 }


### PR DESCRIPTION
Fixes #84 
Fixes #85 
Fixes #86 
Fixes #87 

- feat: shift body validation before role validation
- test: add unit tests for create user controller
- refactor: rename param
- test: add unit tests for delete user controller
- feat: remove next function from list users
- test: add unit tests for list users controller
- fix: change unauthorized to bad request exception
- feat: move body validation logic forward
- test: add unit tests for update controller
