### PR TITLE
test: add unit tests for policies

### DIFF
--- a/src/policy/adminpolicies/policy.test.ts
+++ b/src/policy/adminpolicies/policy.test.ts
@@ -1,0 +1,62 @@
+import Policy, { RolesAbilities } from '../../policy'
+import {
+  generateRandomAbility,
+  generateRandomUser,
+} from '../../services/test/utils'
+import { getUserAbilities } from '../../services/users'
+
+jest.mock('../../services/users', () => ({
+  getUserAbilities: jest.fn(),
+}))
+
+describe('Organisation Policies', () => {
+  const mockUser = generateRandomUser({ id: 1 })
+
+  const allowDecision = 'allow'
+  const denyDecision = 'deny'
+
+  const viewAdminList = Policy.viewAdminListPolicy()
+  const viewOrganisationList = Policy.viewOrganisationListPolicy()
+  const viewOrganisationCategory = Policy.viewOrganisationCategoryPolicy()
+  const createAdmin = Policy.createAdminPolicy()
+  const deleteAdmin = Policy.deleteAdminPolicy()
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe('Member', () => {
+    const memberAbilites = RolesAbilities['member'].map((name) =>
+      generateRandomAbility({ name: name })
+    )
+
+    beforeEach(() => {
+      jest.mocked(getUserAbilities).mockResolvedValue(memberAbilites)
+    })
+
+    test('Should not be allowed to view admin', async () => {
+      const res = await viewAdminList.Validate()
+      expect(res).toBe(denyDecision)
+    })
+
+    test('Should be allowed to view organisations list', async () => {
+      const res = await viewOrganisationList.Validate()
+      expect(res).toBe(allowDecision)
+    })
+
+    test('Should be allowed to view organisations category', async () => {
+      const res = await viewOrganisationCategory.Validate()
+      expect(res).toBe(allowDecision)
+    })
+
+    test('Should not be allowed to create admins', async () => {
+      const res = await createAdmin.Validate()
+      expect(res).toBe(denyDecision)
+    })
+
+    test('Should not be allowed to delete admins', async () => {
+      const res = await deleteAdmin.Validate()
+      expect(res).toBe(denyDecision)
+    })
+  })
+})

--- a/src/policy/bookingpolicies/advance.test.ts
+++ b/src/policy/bookingpolicies/advance.test.ts
@@ -1,0 +1,36 @@
+import { BookingPayload } from '../../services/bookings'
+import { AllowIfBookingWithin14Days } from '../bookingpolicies/advance'
+
+describe('AllowIfBookingWithin14Days Policy', () => {
+  const now = new Date()
+  const fifteenDaysInFuture = new Date()
+  fifteenDaysInFuture.setDate(now.getDate() + 15)
+
+  let mockBooking: BookingPayload = {
+    eventName: 'test',
+    userId: 1,
+    venueId: 1,
+    start: fifteenDaysInFuture,
+    end: fifteenDaysInFuture,
+    userOrgId: 1,
+  }
+
+  test('should deny if booking is more than  14 days in the future', async () => {
+    const policy = new AllowIfBookingWithin14Days(mockBooking)
+    const decision = await policy.Validate()
+    expect(decision).toEqual('deny')
+    expect(policy.Reason()).toEqual(
+      'You can only book up to 14 days in advance'
+    )
+  })
+
+  test('should allow if booking is within  14 days', async () => {
+    const thirteenDaysInFuture = new Date()
+    thirteenDaysInFuture.setDate(now.getDate() + 13)
+    mockBooking.start = thirteenDaysInFuture
+    mockBooking.end = thirteenDaysInFuture
+    const policy = new AllowIfBookingWithin14Days(mockBooking)
+    const decision = await policy.Validate()
+    expect(decision).toEqual('allow')
+  })
+})

--- a/src/policy/bookingpolicies/belong.test.ts
+++ b/src/policy/bookingpolicies/belong.test.ts
@@ -1,0 +1,31 @@
+import { BookingPayload } from '../../services/bookings'
+import { generateRandomUser } from '../../services/test/utils'
+import { AllowIfBookingBelongToUser } from './belong'
+
+describe('AllowIfBookingBelongToUser Policy', () => {
+  const user = generateRandomUser({ id: 1 })
+  const mockBooking: BookingPayload = {
+    eventName: 'test',
+    userId: 1,
+    venueId: 1,
+    start: new Date(),
+    end: new Date(),
+    userOrgId: 1,
+  }
+
+  test('Should allow if booking belongs to user', async () => {
+    const policy = new AllowIfBookingBelongToUser(mockBooking, user)
+    const decision = await policy.Validate()
+    expect(decision).toEqual('allow')
+  })
+
+  test('Should deny if booking does not belong to user', async () => {
+    const policy = new AllowIfBookingBelongToUser(
+      mockBooking,
+      generateRandomUser({ id: 2 })
+    )
+    const decision = await policy.Validate()
+    expect(decision).toEqual('deny')
+    expect(policy.Reason()).toEqual('This booking does not belong to you.')
+  })
+})

--- a/src/policy/bookingpolicies/stacked.test.ts
+++ b/src/policy/bookingpolicies/stacked.test.ts
@@ -1,0 +1,38 @@
+import { checkStackedBookings } from '../../middlewares/checks'
+import { BookingPayload } from '../../services/bookings'
+import { AllowIfBookingIsNotStacked } from './stacked'
+
+jest.mock('../../middlewares/checks', () => ({
+  checkStackedBookings: jest.fn(),
+}))
+
+describe('AllowIfBookingIsNotStacked Policy', () => {
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+  const mockBooking: BookingPayload = {
+    eventName: 'test',
+    userId: 1,
+    venueId: 1,
+    start: new Date(),
+    end: new Date(),
+    userOrgId: 1,
+  }
+
+  test('Should allow if bookings are not stacked', async () => {
+    jest.mocked(checkStackedBookings).mockResolvedValue(true)
+    const policy = new AllowIfBookingIsNotStacked(mockBooking)
+    const decision = await policy.Validate()
+    expect(decision).toEqual('allow')
+  })
+
+  test('Should deny if bookings are stacked', async () => {
+    jest.mocked(checkStackedBookings).mockResolvedValue(false)
+    const policy = new AllowIfBookingIsNotStacked(mockBooking)
+    const decision = await policy.Validate()
+    expect(decision).toEqual('deny')
+    expect(policy.Reason()).toMatch(
+      /Please leave a duration of at least \d+ minutes in between consecutive bookings/
+    )
+  })
+})

--- a/src/policy/bookingpolicies/too-long.test.ts
+++ b/src/policy/bookingpolicies/too-long.test.ts
@@ -1,0 +1,45 @@
+import { DURATION_PER_SLOT, MAX_SLOTS_PER_BOOKING } from './../../config/common'
+import { AllowIfBookingIsNotTooLong } from './too-long'
+
+jest.mock('../../config/common', () => ({
+  DURATION_PER_SLOT: 30,
+  MAX_SLOTS_PER_BOOKING: 3,
+}))
+
+describe('AllowIfBookingIsNotTooLong Policy', () => {
+  const maxDurationInMs = DURATION_PER_SLOT * MAX_SLOTS_PER_BOOKING * 1000 * 60
+
+  test('Should allow if booking is not too long', async () => {
+    const mockBooking = {
+      eventName: 'test',
+      userId: 1,
+      venueId: 1,
+      start: new Date(),
+      end: new Date(Date.now() + maxDurationInMs),
+      userOrgId: 1,
+    }
+    const policy = new AllowIfBookingIsNotTooLong(mockBooking)
+    const decision = await policy.Validate()
+    expect(decision).toEqual('allow')
+  })
+
+  test('Should deny if booking is too long', async () => {
+    const mockBooking = {
+      eventName: 'test',
+      userId: 1,
+      venueId: 1,
+      start: new Date(),
+      end: new Date(Date.now() + maxDurationInMs + 1),
+      userOrgId: 1,
+    }
+    const policy = new AllowIfBookingIsNotTooLong(mockBooking)
+    const decision = await policy.Validate()
+    expect(decision).toEqual('deny')
+    expect(policy.Reason()).toEqual(
+      'Booking duration is too long, please change your booking request.'
+    )
+    // Assert that the mocked values are being used
+    expect(DURATION_PER_SLOT).toBe(30)
+    expect(MAX_SLOTS_PER_BOOKING).toBe(3)
+  })
+})

--- a/src/policy/bookingpolicies/too-short.test.ts
+++ b/src/policy/bookingpolicies/too-short.test.ts
@@ -1,0 +1,44 @@
+import { AllowIfBookingIsNotTooShort } from './too-short'
+import { MIN_SLOTS_PER_BOOKING, DURATION_PER_SLOT } from './../../config/common'
+jest.mock('../../config/common', () => ({
+  DURATION_PER_SLOT: 30,
+  MIN_SLOTS_PER_BOOKING: 3,
+}))
+
+describe('AllowIfBookingIsNotTooShort', () => {
+  const minDurationInMs = DURATION_PER_SLOT * MIN_SLOTS_PER_BOOKING * 1000 * 60
+
+  test('Should allow if booking is not too short', async () => {
+    const mockBooking = {
+      eventName: 'test',
+      userId: 1,
+      venueId: 1,
+      start: new Date(),
+      end: new Date(Date.now() + minDurationInMs),
+      userOrgId: 1,
+    }
+    const policy = new AllowIfBookingIsNotTooShort(mockBooking)
+    const decision = await policy.Validate()
+    expect(decision).toEqual('allow')
+  })
+
+  test('Should deny if booking is too short', async () => {
+    const mockBooking = {
+      eventName: 'test',
+      userId: 1,
+      venueId: 1,
+      start: new Date(),
+      end: new Date(Date.now() + minDurationInMs - 1),
+      userOrgId: 1,
+    }
+    const policy = new AllowIfBookingIsNotTooShort(mockBooking)
+    const decision = await policy.Validate()
+    expect(decision).toEqual('deny')
+    expect(policy.Reason()).toEqual(
+      'Booking duration is too short, please change your booking request.'
+    )
+    // Assert that the mocked values are being used
+    expect(DURATION_PER_SLOT).toBe(30)
+    expect(MIN_SLOTS_PER_BOOKING).toBe(3)
+  })
+})

--- a/src/policy/bookingpolicies/two-hour.test.ts
+++ b/src/policy/bookingpolicies/two-hour.test.ts
@@ -1,0 +1,45 @@
+import { AllowIfBookingLessThanTwoHours } from './two-hour'
+describe('AllowIfBookingLessThanTwoHours policy', () => {
+  test('Should allow if booking is less than 2 hours', async () => {
+    const mockBooking = {
+      eventName: 'test',
+      userId: 1,
+      venueId: 1,
+      start: new Date(),
+      end: new Date(Date.now() + 2 * 60 * 60 * 1000 - 1),
+      userOrgId: 1,
+    }
+    const policy = new AllowIfBookingLessThanTwoHours(mockBooking)
+    const decision = await policy.Validate()
+    expect(decision).toEqual('allow')
+  })
+
+  test('Should allow if booking is equal to 2 hours', async () => {
+    const mockBooking = {
+      eventName: 'test',
+      userId: 1,
+      venueId: 1,
+      start: new Date(),
+      end: new Date(Date.now() + 2 * 60 * 60 * 1000),
+      userOrgId: 1,
+    }
+    const policy = new AllowIfBookingLessThanTwoHours(mockBooking)
+    const decision = await policy.Validate()
+    expect(decision).toEqual('allow')
+  })
+
+  test('Should deny if booking is more than 2 hours', async () => {
+    const mockBooking = {
+      eventName: 'test',
+      userId: 1,
+      venueId: 1,
+      start: new Date(),
+      end: new Date(Date.now() + 2 * 60 * 60 * 1000 + 1),
+      userOrgId: 1,
+    }
+    const policy = new AllowIfBookingLessThanTwoHours(mockBooking)
+    const decision = await policy.Validate()
+    expect(decision).toEqual('deny')
+    expect(policy.Reason()).toEqual('Booking duration is longer than 2 hours.')
+  })
+})

--- a/src/policy/organisationpolicies/policy.test.ts
+++ b/src/policy/organisationpolicies/policy.test.ts
@@ -1,0 +1,56 @@
+import Policy, { RolesAbilities } from '../../policy'
+import {
+  generateRandomAbility,
+  generateRandomUser,
+} from '../../services/test/utils'
+import { getUserAbilities } from '../../services/users'
+
+jest.mock('../../services/users', () => ({
+  getUserAbilities: jest.fn(),
+}))
+
+describe('Organisation Policies', () => {
+  const mockUser = generateRandomUser({ id: 1 })
+
+  const allowDecision = 'allow'
+  const denyDecision = 'deny'
+
+  const listOrg = Policy.listOrgsPolicy()
+  const createOrg = Policy.createOrgPolicy()
+  const updateOrg = Policy.updateOrgPolicy()
+  const deleteOrg = Policy.deleteOrgPolicy()
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe('Member', () => {
+    const memberAbilites = RolesAbilities['member'].map((name) =>
+      generateRandomAbility({ name: name })
+    )
+
+    beforeEach(() => {
+      jest.mocked(getUserAbilities).mockResolvedValue(memberAbilites)
+    })
+
+    test('Should be allowed to view organisations', async () => {
+      const res = await listOrg.Validate()
+      expect(res).toBe(allowDecision)
+    })
+
+    test('Should not be allowed to create organisations', async () => {
+      const res = await createOrg.Validate()
+      expect(res).toBe(denyDecision)
+    })
+
+    test('Should not be allowed to update organisations', async () => {
+      const res = await updateOrg.Validate()
+      expect(res).toBe(denyDecision)
+    })
+
+    test('Should not be allowed to update organisations', async () => {
+      const res = await deleteOrg.Validate()
+      expect(res).toBe(denyDecision)
+    })
+  })
+})

--- a/src/policy/rolesabilities/util.ts
+++ b/src/policy/rolesabilities/util.ts
@@ -21,6 +21,7 @@ export const RolesAbilities: Record<RoleName, AbilityName[]> = {
     Abilities.canCreateSubmission,
     Abilities.canUpdateSubmission,
     Abilities.canDeleteSubmission,
+    Abilities.canPublishSubmission,
   ],
   [Roles.BookingAdmin]: [
     Abilities.canViewAdminList,

--- a/src/policy/submissionpolicies/policy.test.ts
+++ b/src/policy/submissionpolicies/policy.test.ts
@@ -1,0 +1,97 @@
+import Policy, { RolesAbilities } from '../../policy'
+import {
+  generateRandomAbility,
+  generateRandomUser,
+} from '../../services/test/utils'
+import { getUserAbilities } from '../../services/users'
+
+jest.mock('../../services/users', () => ({
+  getUserAbilities: jest.fn(),
+}))
+
+describe('Submission Policies', () => {
+  const mockUser = generateRandomUser({ id: 1 })
+
+  const allowDecision = 'allow'
+  const denyDecision = 'deny'
+
+  const viewSubmission = Policy.viewSubmissionPolicy()
+  const createSubmission = Policy.createSubmissionPolicy()
+  const updateSubmission = Policy.updateSubmissionPolicy()
+  const publishSubmission = Policy.publishSubmissionPolicy()
+  const deleteSubmission = Policy.deleteSubmissionPolicy()
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe('Member', () => {
+    const memberAbilites = RolesAbilities['member'].map((name) =>
+      generateRandomAbility({ name: name })
+    )
+
+    beforeEach(() => {
+      jest.mocked(getUserAbilities).mockResolvedValue(memberAbilites)
+    })
+
+    test('Should be allowed to view submission', async () => {
+      const res = await viewSubmission.Validate(mockUser)
+      expect(res).toBe(allowDecision)
+    })
+
+    test('Should not be allowed to create submission', async () => {
+      const res = await createSubmission.Validate(mockUser)
+      expect(res).toBe(denyDecision)
+    })
+
+    test('Should not be allowed to update submission', async () => {
+      const res = await updateSubmission.Validate(mockUser)
+      expect(res).toBe(denyDecision)
+    })
+
+    test('Should not be allowed to publish submission', async () => {
+      const res = await publishSubmission.Validate(mockUser)
+      expect(res).toBe(denyDecision)
+    })
+
+    test('Should not be allowed to delete submission', async () => {
+      const res = await deleteSubmission.Validate(mockUser)
+      expect(res).toBe(denyDecision)
+    })
+  })
+
+  describe('AcadsAdmin', () => {
+    const acadsAdminAbilities = RolesAbilities['acads_admin'].map((name) =>
+      generateRandomAbility({ name })
+    )
+
+    beforeEach(() => {
+      jest.mocked(getUserAbilities).mockResolvedValue(acadsAdminAbilities)
+    })
+
+    test('Should be allowed to view submission', async () => {
+      const res = await viewSubmission.Validate(mockUser)
+      expect(res).toBe(allowDecision)
+    })
+
+    test('Should be allowed to create submission', async () => {
+      const res = await createSubmission.Validate(mockUser)
+      expect(res).toBe(allowDecision)
+    })
+
+    test('Should be allowed to update submission', async () => {
+      const res = await updateSubmission.Validate(mockUser)
+      expect(res).toBe(allowDecision)
+    })
+
+    test('Should be allowed to publish submission', async () => {
+      const res = await publishSubmission.Validate(mockUser)
+      expect(res).toBe(allowDecision)
+    })
+
+    test('Should be allowed to delete submission', async () => {
+      const res = await deleteSubmission.Validate(mockUser)
+      expect(res).toBe(allowDecision)
+    })
+  })
+})

--- a/src/policy/userpolicies/policy.test.ts
+++ b/src/policy/userpolicies/policy.test.ts
@@ -1,0 +1,56 @@
+import Policy, { RolesAbilities } from '../../policy'
+import {
+  generateRandomAbility,
+  generateRandomUser,
+} from '../../services/test/utils'
+import { getUserAbilities } from '../../services/users'
+
+jest.mock('../../services/users', () => ({
+  getUserAbilities: jest.fn(),
+}))
+
+describe('User Policies', () => {
+  const mockUser = generateRandomUser({ id: 1 })
+
+  const allowDecision = 'allow'
+  const denyDecision = 'deny'
+
+  const listUser = Policy.listUserPolicy()
+  const createUser = Policy.createUserPolicy()
+  const updateUser = Policy.updateUserPolicy()
+  const deleteUser = Policy.deleteUserPolicy()
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe('Member', () => {
+    const memberAbilites = RolesAbilities['member'].map((name) =>
+      generateRandomAbility({ name: name })
+    )
+
+    beforeEach(() => {
+      jest.mocked(getUserAbilities).mockResolvedValue(memberAbilites)
+    })
+
+    test('Should be allowed to view users', async () => {
+      const res = await listUser.Validate()
+      expect(res).toBe(allowDecision)
+    })
+
+    test('Should not be allowed to create users', async () => {
+      const res = await createUser.Validate()
+      expect(res).toBe(denyDecision)
+    })
+
+    test('Should not be allowed to update users', async () => {
+      const res = await updateUser.Validate()
+      expect(res).toBe(denyDecision)
+    })
+
+    test('Should not be allowed to update users', async () => {
+      const res = await deleteUser.Validate()
+      expect(res).toBe(denyDecision)
+    })
+  })
+})

--- a/src/policy/venuepolicies/policy.test.ts
+++ b/src/policy/venuepolicies/policy.test.ts
@@ -1,0 +1,38 @@
+import Policy, { RolesAbilities } from '../../policy'
+import {
+  generateRandomAbility,
+  generateRandomUser,
+} from '../../services/test/utils'
+import { getUserAbilities } from '../../services/users'
+
+jest.mock('../../services/users', () => ({
+  getUserAbilities: jest.fn(),
+}))
+
+describe('Venue Policies', () => {
+  const mockUser = generateRandomUser({ id: 1 })
+
+  const allowDecision = 'allow'
+  const denyDecision = 'deny'
+
+  const listVenues = Policy.listVenuePolicy()
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe('Member', () => {
+    const memberAbilites = RolesAbilities['member'].map((name) =>
+      generateRandomAbility({ name: name })
+    )
+
+    beforeEach(() => {
+      jest.mocked(getUserAbilities).mockResolvedValue(memberAbilites)
+    })
+
+    test('Should be allowed to view venues', async () => {
+      const res = await listVenues.Validate()
+      expect(res).toBe(allowDecision)
+    })
+  })
+})


### PR DESCRIPTION
- fix: add missing ability for acads admin
- test: add unit tests for submission policies
- test: add unit test for admin, venue, user, org policies
- test: add unit tests for booking helper policies
