### PR TITLE
feat: update folio policies

### DIFF
--- a/src/policy/abilities/submission.ts
+++ b/src/policy/abilities/submission.ts
@@ -4,7 +4,6 @@ export const canViewSubmissionList: AbilityName = 'canViewSubmissionList'
 export const canCreateSubmission: AbilityName = 'canCreateSubmission'
 export const canUpdateSubmission: AbilityName = 'canUpdateSubmission'
 export const canDeleteSubmission: AbilityName = 'canDeleteSubmission'
-export const canPublishSubmission: AbilityName = 'canApproveSubmission'
 
 export const canViewSubmissionListAbility: Create<Ability> = {
   name: canViewSubmissionList,
@@ -26,15 +25,9 @@ export const canDeleteSubmissionAbility: Create<Ability> = {
   description: 'Can delete submission',
 }
 
-export const canPublishSubmissionAbility: Create<Ability> = {
-  name: canPublishSubmission,
-  description: 'Can publish submission',
-}
-
 export const AllSubmissionAbilities: Create<Ability>[] = [
   canViewSubmissionListAbility,
   canCreateSubmissionAbility,
   canUpdateSubmissionAbility,
   canDeleteSubmissionAbility,
-  canPublishSubmissionAbility,
 ]

--- a/src/policy/rolesabilities/util.ts
+++ b/src/policy/rolesabilities/util.ts
@@ -21,7 +21,6 @@ export const RolesAbilities: Record<RoleName, AbilityName[]> = {
     Abilities.canCreateSubmission,
     Abilities.canUpdateSubmission,
     Abilities.canDeleteSubmission,
-    Abilities.canPublishSubmission,
   ],
   [Roles.BookingAdmin]: [
     Abilities.canViewAdminList,

--- a/src/policy/submissionpolicies/policy.test.ts
+++ b/src/policy/submissionpolicies/policy.test.ts
@@ -18,7 +18,6 @@ describe('Submission Policies', () => {
   const viewSubmission = Policy.viewSubmissionPolicy()
   const createSubmission = Policy.createSubmissionPolicy()
   const updateSubmission = Policy.updateSubmissionPolicy()
-  const publishSubmission = Policy.publishSubmissionPolicy()
   const deleteSubmission = Policy.deleteSubmissionPolicy()
 
   afterEach(() => {
@@ -35,7 +34,7 @@ describe('Submission Policies', () => {
     })
 
     test('Should be allowed to view submission', async () => {
-      const res = await viewSubmission.Validate(mockUser)
+      const res = await viewSubmission.Validate()
       expect(res).toBe(allowDecision)
     })
 
@@ -46,11 +45,6 @@ describe('Submission Policies', () => {
 
     test('Should not be allowed to update submission', async () => {
       const res = await updateSubmission.Validate(mockUser)
-      expect(res).toBe(denyDecision)
-    })
-
-    test('Should not be allowed to publish submission', async () => {
-      const res = await publishSubmission.Validate(mockUser)
       expect(res).toBe(denyDecision)
     })
 
@@ -70,7 +64,7 @@ describe('Submission Policies', () => {
     })
 
     test('Should be allowed to view submission', async () => {
-      const res = await viewSubmission.Validate(mockUser)
+      const res = await viewSubmission.Validate()
       expect(res).toBe(allowDecision)
     })
 
@@ -81,11 +75,6 @@ describe('Submission Policies', () => {
 
     test('Should be allowed to update submission', async () => {
       const res = await updateSubmission.Validate(mockUser)
-      expect(res).toBe(allowDecision)
-    })
-
-    test('Should be allowed to publish submission', async () => {
-      const res = await publishSubmission.Validate(mockUser)
       expect(res).toBe(allowDecision)
     })
 

--- a/src/policy/submissionpolicies/policy.ts
+++ b/src/policy/submissionpolicies/policy.ts
@@ -20,12 +20,6 @@ export const updateSubmissionPolicy = () => {
   )
 }
 
-export const publishSubmissionPolicy = () => {
-  return new Policies.Any(
-    new Policies.HasAnyAbilities(Abilities.canPublishSubmission)
-  )
-}
-
 export const deleteSubmissionPolicy = () => {
   return new Policies.Any(
     new Policies.HasAnyAbilities(Abilities.canDeleteSubmission)

--- a/src/policy/submissionpolicies/policy.ts
+++ b/src/policy/submissionpolicies/policy.ts
@@ -1,10 +1,11 @@
 import * as Policies from '../commonpolicies'
 import * as Abilities from '../abilities'
 
+/**
+ * All users, even non-members, are allowed to view submissions.
+ */
 export const viewSubmissionPolicy = () => {
-  return new Policies.Any(
-    new Policies.HasAnyAbilities(Abilities.canViewSubmissionList)
-  )
+  return new Policies.Allow()
 }
 
 export const createSubmissionPolicy = () => {


### PR DESCRIPTION

# Notes:

Fixes #139 
Also known as "Submission policies".
This PR removes "publish submission" as a policy as the behaviour is subsumed under
"update submission".

## Commits:

- feat: update view submission policy
- feat: remove publish submission policy
