### PR TITLE
feat: add folio / submissions service

### DIFF
--- a/prisma/helper/submissions.ts
+++ b/prisma/helper/submissions.ts
@@ -1,0 +1,315 @@
+import { prisma } from '../../db'
+
+// TODO: Move the data elsewhere
+const courses: Array<{ code: string; name: string }> = [
+  {
+    code: 'NGN2001',
+    name: 'Global Narratives',
+  },
+  {
+    code: 'NTW2006',
+    name: 'Human Trafficking and Labour Migration',
+  },
+  {
+    code: 'NTW2010',
+    name: 'Sites of Tourism',
+  },
+  {
+    code: 'NTW2029',
+    name: 'Evolutionary Psychology and Art',
+  },
+  {
+    code: 'NTW2031',
+    name: 'Equity and Education',
+  },
+  {
+    code: 'NTW2032',
+    name: 'Identity, Death, and Immortality',
+  },
+  {
+    code: 'NTW2033',
+    name: 'Conceptions of Human Nature',
+  },
+  {
+    code: 'NTW2034',
+    name: 'Wild and Simple: Living and Thinking Sustainably',
+  },
+  {
+    code: 'NTW2035',
+    name: 'Art and the Attention Economy',
+  },
+  {
+    code: 'NTW2036',
+    name: 'Space, Place and the Human Experience',
+  },
+  {
+    code: 'NTW2037',
+    name: 'Absences: Beyond the Edges of the Material World',
+  },
+  {
+    code: 'NTW2038',
+    name: 'Screening Historical Trauma',
+  },
+  {
+    code: 'NGT2001',
+    name: 'Global Social Thought',
+  },
+]
+
+export const seedCourses = async () => {
+  console.log('Seeding courses...')
+  await prisma.course.createMany({
+    data: courses,
+  })
+  console.info('Seeding courses finished.')
+}
+
+const professors: Array<{ name: string }> = [
+  // NTW
+  {
+    name: 'Dr Leung Wing Sze',
+  },
+  {
+    name: 'A/P Lo Mun Hou',
+  },
+  {
+    name: 'Dr Jonathan Frome',
+  },
+  {
+    name: 'Dr Amy Ramirez',
+  },
+  {
+    name: 'Dr Jane Loo',
+  },
+  {
+    name: 'Dr Maximillian Tegtmeyer',
+  },
+  {
+    name: 'Dr David Merry',
+  },
+  {
+    name: 'Dr Tan Teck Heng',
+  },
+  {
+    name: 'Dr Tiffany Chuang',
+  },
+  {
+    name: 'Dr Phillip Meadows',
+  },
+  {
+    name: 'Dr John Rhym',
+  },
+  // NGN
+  {
+    name: 'Dr Bart Van Wassenhove',
+  },
+  {
+    name: 'Dr Roweena Yip',
+  },
+  {
+    name: 'Christine Tan',
+  },
+  {
+    name: 'Dr Christine Tan',
+  },
+  {
+    name: 'Dr Emily Dalton',
+  },
+  {
+    name: 'Dr Hannah Smith-Drelich',
+  },
+  {
+    name: 'Dr Carissa Foo',
+  },
+  {
+    name: 'Dr Samar Faruqi',
+  },
+  {
+    name: 'Dr Raahi Adhya',
+  },
+  // NGT
+  {
+    name: 'Dr Bjorn Gomez',
+  },
+  {
+    name: 'Dr Kiven Strohm',
+  },
+  {
+    name: 'Dr Benedek Varga',
+  },
+  {
+    name: 'Dr Amanda Blair',
+  },
+  {
+    name: 'Dr Chen Ying',
+  },
+  {
+    name: 'Dr Gabriel Tusinski',
+  },
+]
+
+export const seedProfessors = async () => {
+  console.log('Seeding professors...')
+  await prisma.professor.createMany({
+    data: professors,
+  })
+  console.info('Seeding professors finished.')
+}
+
+const students: Array<{ name: string; matriculationNo: string }> = [
+  {
+    name: 'John Tan',
+    matriculationNo: 'A0201234B',
+  },
+  {
+    name: 'Jane Tan',
+    matriculationNo: 'A0201235C',
+  },
+]
+
+// Seed course offerings
+const courseOfferings = [
+  {
+    course: {
+      connect: {
+        code: 'NTW2006',
+      },
+    },
+    professor: {
+      connect: {
+        id: 1,
+      },
+    },
+    semester: 'Semester 2',
+    ay: '2022/2023',
+  },
+  {
+    course: {
+      connect: {
+        code: 'NGN2001',
+      },
+    },
+    professor: {
+      connect: {
+        id: 2,
+      },
+    },
+
+    semester: 'Semester 1',
+    ay: '2023/2024',
+  },
+]
+
+export const seedCourseOfferings = async () => {
+  console.log('Seeding course offerings...')
+  await Promise.all(
+    courseOfferings.map((courseOffering) =>
+      prisma.courseOffering.create({ data: courseOffering })
+    )
+  )
+  console.info('Seeding course offerings finished.')
+}
+
+export const seedStudents = async () => {
+  console.log('Seeding students...')
+  await prisma.student.createMany({
+    data: students,
+  })
+  console.info('Seeding students finished.')
+}
+
+const submissions: Array<{
+  title: string
+  text: string
+  student: {
+    connect: {
+      matriculationNo: string
+    }
+  }
+  courseOffering: {
+    connect: {
+      id: number
+    }
+  }
+}> = [
+  {
+    title: 'Human Trafficking and Labour Migration',
+    text: `
+# Human Trafficking and Labour Migration
+
+Human trafficking and labor migration represent **two crucial issues** in contemporary society, practically mirroring each other's existence through the lens of economic necessity and exploitation. Labor migration, fundamentally, is the _movement_ of individuals from their homeland to foreign lands in pursuit of employment opportunities. This phenomenon is driven by the desire for a better life and the global inequity in job availability. Conversely, human trafficking is the dark shadow of labor migration, characterized by coercion, deceit, and force, leading victims into modern forms of slavery.
+
+## The Intricate Link
+The relationship between **human trafficking** and **labor migration** is deeply entwined with global economic disparities. The allure of financial stability and the promise of employment opportunities make individuals from less affluent regions vulnerable to exploitation. Traffickers capitalize on these vulnerabilities, offering deceptive opportunities for a better future that, in reality, lead to exploitative work conditions.
+
+## Combating Human Trafficking
+Addressing the challenges posed by human trafficking within the context of labor migration requires a multi-faceted approach:
+
+- Establishing **safe, legal migration pathways** to reduce reliance on irregular channels that increase vulnerability.
+- Improving economic opportunities in home countries to lessen the need for risky migration.
+- Enhancing international cooperation to dismantle trafficking networks.
+- Educating potential migrants about the risks of trafficking to prevent exploitation.
+- Recognizing and protecting the rights of migrant workers through legal frameworks.
+
+In conclusion, human trafficking and labor migration are complex issues that demand comprehensive, collaborative efforts to ensure migration remains a hopeful choice rather than a pathway to exploitation. Learn more about this at [United Nations Office on Drugs and Crime](https://www.unodc.org/).`,
+    student: {
+      connect: {
+        matriculationNo: 'A0201234B',
+      },
+    },
+    courseOffering: {
+      connect: {
+        id: 1,
+      },
+    },
+  },
+  {
+    title: 'Sites of Tourism',
+    text: `# Sites of Tourism
+
+Tourism, a dominant force in the global economy, brings to light the vast array of **natural wonders**, **cultural landmarks**, and modern attractions that captivate visitors worldwide. However, the ramifications of tourism extend beyond economic contributions, affecting social, cultural, and environmental realms.
+
+## The Double-Edged Sword of Tourism
+
+While sites like the **Grand Canyon** and **Machu Picchu** offer unique insights into the natural world and human history, the surge in tourism can lead to significant challenges:
+
+- **Over-tourism**: This phenomenon not only poses a threat to natural environments and wildlife but can also damage historical sites and disrupt local communities with increased living costs and the overshadowing of traditional lifestyles.
+- **Environmental Impact**: Popular tourist destinations may suffer from pollution and habitat destruction due to the influx of visitors.
+
+## Sustainable Tourism as a Solution
+
+The concept of _sustainable tourism_ emphasizes the need for responsible travel practices that support environmental conservation and respect for local communities. Key aspects include:
+
+- Encouraging tourists to engage in eco-friendly practices.
+- Supporting local economies through the ethical purchase of goods and services.
+- Promoting cultural exchange that respects local traditions and heritage.
+
+### Moving Forward
+
+Tourist sites are not just destinations; they are a testament to our world's diversity and beauty. The future of tourism hinges on our ability to foster sustainable practices, ensuring that we preserve the very wonders we cherish. For more insights on sustainable tourism, visit [The Global Sustainable Tourism Council](https://www.gstcouncil.org/).
+
+By embracing the principles of sustainable tourism, we can navigate the complexities of global travel, preserving the integrity of tourist sites while still enjoying the rich experiences they offer.`,
+    student: {
+      connect: {
+        matriculationNo: 'A0201235C',
+      },
+    },
+    courseOffering: {
+      connect: {
+        id: 2,
+      },
+    },
+  },
+]
+
+export const seedSubmissions = async () => {
+  console.log('Seeding submissions...')
+  await Promise.all(
+    submissions.map((submission) =>
+      prisma.submission.create({
+        data: submission,
+      })
+    )
+  )
+  console.info('Seeding submissions finished.')
+}

--- a/prisma/migrations/20240216011713_add_folio_model/migration.sql
+++ b/prisma/migrations/20240216011713_add_folio_model/migration.sql
@@ -28,7 +28,7 @@ CREATE TABLE "CourseOffering" (
 -- CreateTable
 CREATE TABLE "Student" (
     "id" SERIAL NOT NULL,
-    "nusId" TEXT NOT NULL,
+    "matriculationNo" TEXT NOT NULL,
     "name" TEXT NOT NULL,
 
     CONSTRAINT "Student_pkey" PRIMARY KEY ("id")
@@ -48,7 +48,10 @@ CREATE TABLE "Submission" (
 );
 
 -- CreateIndex
-CREATE UNIQUE INDEX "Student_nusId_key" ON "Student"("nusId");
+CREATE UNIQUE INDEX "Professor_name_key" ON "Professor"("name");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Student_matriculationNo_key" ON "Student"("matriculationNo");
 
 -- AddForeignKey
 ALTER TABLE "CourseOffering" ADD CONSTRAINT "CourseOffering_courseCode_fkey" FOREIGN KEY ("courseCode") REFERENCES "Course"("code") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -135,7 +135,7 @@ model CourseOffering {
   course      Course       @relation(fields: [courseCode], references: [code], onDelete: Cascade, onUpdate: Cascade)
   professorId Int
   professor   Professor    @relation(fields: [professorId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  semester    String
+  semester    String // Change to enum?
   ay          String
   submissions Submission[]
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -125,7 +125,7 @@ model Course {
 
 model Professor {
   id              Int              @id @default(autoincrement())
-  name            String
+  name            String           @unique
   courseOfferings CourseOffering[]
 }
 
@@ -141,10 +141,10 @@ model CourseOffering {
 }
 
 model Student {
-  id          Int          @id @default(autoincrement())
-  nusId       String       @unique
-  name        String
-  submissions Submission[]
+  id              Int          @id @default(autoincrement())
+  matriculationNo String       @unique
+  name            String
+  submissions     Submission[]
 }
 
 model Submission {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -20,6 +20,13 @@ import {
   seedRolesAbilities,
 } from './helper/roles-abilities'
 import { seedDevInfo } from './helper/dev-info'
+import {
+  seedCourseOfferings,
+  seedCourses,
+  seedProfessors,
+  seedStudents,
+  seedSubmissions,
+} from './helper/submissions'
 
 const excelFile = process.env.EXCEL_SEED_FILEPATH as string
 
@@ -109,6 +116,13 @@ async function main() {
   }
 
   await seedOrgRoles(excelFile, getDevSheetName(orgRoleSheet))
+
+  // Folio Submissions
+  await seedCourses()
+  await seedProfessors()
+  await seedStudents()
+  await seedCourseOfferings()
+  await seedSubmissions()
 
   console.log(`Seeding finished.`)
 }

--- a/src/services/submissions.test.ts
+++ b/src/services/submissions.test.ts
@@ -1,0 +1,63 @@
+import { prismaMock } from './test/singleton'
+import { addSubmission, deleteSubmission } from './submissions'
+import {
+  generateRandomSubmission,
+  generateRandomStudent,
+  generateRandomCourseOffering,
+} from './test/utils'
+import { Submission } from '@prisma/client'
+import { HttpException } from '../exceptions/HttpException'
+
+beforeEach(() => {
+  jest.resetAllMocks()
+})
+
+// Note: we do not add tests for other service methods as they only call prisma methods
+
+describe('addSubmission', () => {
+  test('add succeeds', async () => {
+    const student = generateRandomStudent()
+    const courseOffering = generateRandomCourseOffering()
+    const submissionToAdd = {
+      title: 'Test Submission',
+      text: 'This is a test submission.',
+      matriculationNo: student.matriculationNo,
+      courseOfferingId: courseOffering.id,
+    }
+
+    const addedSubmission: Submission =
+      generateRandomSubmission(submissionToAdd)
+    prismaMock.submission.create.mockResolvedValue(addedSubmission)
+
+    const result = addSubmission(submissionToAdd)
+
+    await expect(result).resolves.toEqual({
+      ...addedSubmission,
+      id: expect.any(Number),
+    })
+  })
+})
+
+describe('deleteSubmission', () => {
+  test('delete succeeds', async () => {
+    const testSubmission = generateRandomSubmission()
+
+    prismaMock.submission.findFirst.mockResolvedValueOnce(testSubmission)
+    prismaMock.submission.delete.mockResolvedValue(testSubmission)
+
+    await expect(deleteSubmission(testSubmission.id)).resolves.toEqual(
+      testSubmission
+    )
+  })
+
+  test('delete fails', async () => {
+    prismaMock.submission.findFirst.mockResolvedValueOnce(null)
+    try {
+      await deleteSubmission(1)
+    } catch (e) {
+      expect(e).toBeInstanceOf(HttpException)
+      const exception = e as HttpException
+      expect(exception.message).toMatch(/Submission with id 1 not found/)
+    }
+  })
+})

--- a/src/services/submissions.ts
+++ b/src/services/submissions.ts
@@ -1,0 +1,135 @@
+import {
+  Course,
+  CourseOffering,
+  Professor,
+  Student,
+  Submission,
+} from '@prisma/client'
+import { prisma } from '../../db'
+import { HttpCode, HttpException } from '@/exceptions'
+
+// Submission should include the Course, Professor and Student associated
+export type DetailedSubmission = Submission & {
+  student: Student
+  courseOffering: CourseOffering & {
+    course: Course
+    professor: Professor
+  }
+}
+
+// Helper object to include the Course, Professor and Student associated
+const submissionInclude = {
+  courseOffering: {
+    include: {
+      course: true,
+      professor: true,
+    },
+  },
+  student: true,
+}
+
+// Get all submissions
+export async function getAllSubmissions(): Promise<DetailedSubmission[]> {
+  return prisma.submission.findMany({
+    include: submissionInclude,
+  })
+}
+
+// Get submissions by course code e.g. NGN2001
+export async function getSubmissionsByCourseCode(
+  code: Course['code']
+): Promise<DetailedSubmission[]> {
+  return prisma.submission.findMany({
+    where: {
+      courseOffering: {
+        course: {
+          code,
+        },
+      },
+    },
+    include: submissionInclude,
+  })
+}
+
+// Get submissions by AY and Sem e.g. 2023/2024, Semester 1
+export async function getSubmissionsByAYSem(
+  ay: CourseOffering['ay'],
+  semester: CourseOffering['semester']
+): Promise<DetailedSubmission[]> {
+  return prisma.submission.findMany({
+    where: {
+      courseOffering: {
+        ay,
+        semester,
+      },
+    },
+    include: submissionInclude,
+  })
+}
+
+// Get submission by id
+export async function getSubmissionById(
+  id: Submission['id']
+): Promise<DetailedSubmission> {
+  return prisma.submission.findFirstOrThrow({
+    where: { id },
+    include: submissionInclude,
+  })
+}
+
+export type SubmissionPayload = Pick<Submission, 'title' | 'text'> & {
+  matriculationNo: Student['matriculationNo']
+  courseOfferingId: CourseOffering['id']
+}
+// Add submission
+export async function addSubmission({
+  title,
+  text,
+  matriculationNo,
+  courseOfferingId,
+}: SubmissionPayload): Promise<DetailedSubmission> {
+  return prisma.submission.create({
+    data: {
+      title,
+      text,
+      student: {
+        connect: {
+          matriculationNo,
+        },
+      },
+      courseOffering: {
+        connect: {
+          id: courseOfferingId,
+        },
+      },
+    },
+    include: submissionInclude,
+  })
+}
+
+// Update submission
+export async function updateSubmission(
+  id: Submission['id'],
+  { title, text }: Pick<Submission, 'title' | 'text'>
+): Promise<DetailedSubmission> {
+  return prisma.submission.update({
+    where: { id },
+    data: { title, text },
+    include: submissionInclude,
+  })
+}
+
+// Delete submission
+export async function deleteSubmission(
+  id: Submission['id']
+): Promise<DetailedSubmission> {
+  const exists = await prisma.submission.findFirst({ where: { id } })
+  if (!exists) {
+    throw new HttpException(
+      `Submission with id ${id} not found`,
+      HttpCode.BadRequest
+    )
+  }
+
+  return prisma.submission.delete({ where: { id }, include: submissionInclude })
+}

--- a/src/services/test/utils.ts
+++ b/src/services/test/utils.ts
@@ -1,14 +1,20 @@
 import {
   Ability,
   Booking,
+  Course,
+  CourseOffering,
   Organisation,
+  Professor,
   Role,
+  Student,
+  Submission,
   User,
   UserOnOrg,
   Venue,
 } from '@prisma/client'
 import { faker } from '@faker-js/faker'
 import { IGCategory } from '@prisma/client'
+import { DetailedSubmission, SubmissionPayload } from '../submissions'
 
 function generateRandomIgCategory() {
   const categories = Object.values(IGCategory)
@@ -110,5 +116,96 @@ export function generateRandomRole(Role?: Partial<Role>): Role {
     name: faker.lorem.words(),
     createdAt: faker.datatype.datetime(),
     ...Role,
+  }
+}
+
+// Folio
+export function generateRandomProfessor(
+  professor?: Partial<Professor>
+): Professor {
+  return {
+    id: generateRandomTableId(),
+    name: faker.name.firstName(),
+    ...professor,
+  }
+}
+
+export function generateRandomCourse(course?: Partial<Course>): Course {
+  return {
+    code: faker.lorem.slug(1),
+    name: faker.lorem.words(),
+    ...course,
+  }
+}
+
+export function generateRandomCourseOffering(
+  courseOffering?: Partial<CourseOffering>
+): CourseOffering {
+  return {
+    id: generateRandomTableId(),
+    courseCode: faker.lorem.slug(1),
+    professorId: generateRandomTableId(),
+    ay: faker.lorem.words(),
+    semester: faker.lorem.words(),
+    ...courseOffering,
+  }
+}
+
+export function generateRandomStudent(student?: Partial<Student>): Student {
+  return {
+    id: generateRandomTableId(),
+    matriculationNo: faker.datatype.number().toString(),
+    name: faker.name.firstName(),
+    ...student,
+  }
+}
+
+export function generateRandomSubmission(
+  submission?: Partial<Submission>
+): Submission {
+  return {
+    id: generateRandomTableId(),
+    title: faker.lorem.words(),
+    text: faker.lorem.paragraph(),
+    lastUpdated: faker.datatype.datetime(),
+    isPublished: faker.datatype.boolean(),
+    studentId: generateRandomTableId(),
+    courseOfferingId: generateRandomTableId(),
+    ...submission,
+  }
+}
+
+export function generateRandomSubmissionPayload(
+  submissionPayload?: Partial<SubmissionPayload>
+): SubmissionPayload {
+  return {
+    title: faker.lorem.words(),
+    text: faker.lorem.paragraph(),
+    matriculationNo: faker.datatype.number().toString(),
+    courseOfferingId: generateRandomTableId(),
+    ...submissionPayload,
+  }
+}
+
+export function generateRandomDetailedSubmission(
+  submission?: Partial<Submission>,
+  course?: Partial<Course>,
+  professor?: Partial<Professor>,
+  student?: Partial<Student>
+): DetailedSubmission {
+  return {
+    ...generateRandomSubmission(submission),
+    courseOffering: {
+      ...generateRandomCourseOffering(),
+      course: {
+        ...generateRandomCourse(course),
+      },
+      professor: {
+        ...generateRandomProfessor(professor),
+      },
+    },
+    student: {
+      ...generateRandomStudent(student),
+    },
   }
 }


### PR DESCRIPTION
Fixes #140

Note: 
I did not add unit tests for most of the methods as they only involve calls to Prisma.
`DetailedSubmission` returns both title and text of all submissions. In the future, we might have to handle many submissions by either 
1. paginating results
2. only returning titles, and fetching the full body of text later

However, to avoid over-optimisation, we will ignore this consideration for now.

- feat: update folio schema
- feat: add seed script for folio
- style: add todo commment
- feat: add utils for folio tests
- feat: create submissions / folio service
