### PR TITLE
fix: handle case in usernames

### DIFF
--- a/src/controllers/auth/login.ts
+++ b/src/controllers/auth/login.ts
@@ -86,7 +86,10 @@ export async function handleLogin(
     ? [
         // In development, we don't have the telegramId
         {
-          telegramUserName: userCredentials.username,
+          telegramUserName: {
+            equals: userCredentials.username,
+            mode: 'insensitive',
+          },
         },
       ]
     : [
@@ -95,7 +98,10 @@ export async function handleLogin(
         },
         {
           telegramId: null,
-          telegramUserName: userCredentials.username,
+          telegramUserName: {
+            equals: userCredentials.username,
+            mode: 'insensitive',
+          },
         },
       ]
 


### PR DESCRIPTION
Currently, multiple users can be created with the same
Telegram username, but different casing, for example
`johntan123` or `JohnTan123`.

This is an issue, as we can't guarantee what's the casing of the
username returned from Telegram.
Thus, if the casing doesn't match exactly, the user is unable
to log in.

This commit fixes it by adding a check when creating new users.
If the new user matches an existing user's username (case-insensitive),
we don't allow the new user to be created.
We add this check in the backend code and not in the database directly
as Prisma doesn't support case-insensitive indexes.

Together with this commit, the duplicate accounts created as a result
of the bug have been deleted.
We can tell that the duplicate accounts are stale as they have no
`telegramId` field, which is only set when the user first logs in.
This means the user has never logged in to those stale accounts
before and they can safely deleted.
