### PR TITLE
fix: remove check for telegramId

### DIFF
--- a/src/services/users.ts
+++ b/src/services/users.ts
@@ -17,9 +17,6 @@ export async function addUser(userPayload: UserPayload): Promise<User> {
     where: {
       OR: [
         {
-          telegramId: userPayload.telegramId,
-        },
-        {
           telegramUserName: {
             equals: userPayload.telegramUserName,
             mode: 'insensitive',


### PR DESCRIPTION
The telegramId field when adding a user is null.