### PR TITLE
Missing bookings audit trail 

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test:unit": "jest -c ./jest.config.js --coverage --verbose",
     "test:unit:watch": "jest -c ./jest.config.js --watch",
     "build": "npm run prisma:generate && tsc",
-    "start": "npm run build && node -r ts-node/register/transpile-only -r tsconfig-paths/register dist/src/app.js",
+    "start": "npm run prisma:migrate && npm run build && node -r ts-node/register/transpile-only -r tsconfig-paths/register dist/src/app.js",
     "dev": "cross-env NODE_ENV=development nodemon",
     "lint": "eslint --ignore-path .gitignore src/**/*.{js,ts,json}",
     "lint:fix": "npm run lint -- --fix",

--- a/prisma/migrations/20241007144551_bookings_soft_delete/migration.sql
+++ b/prisma/migrations/20241007144551_bookings_soft_delete/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Booking" ADD COLUMN     "deleted" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -87,6 +87,7 @@ model Booking {
   start          DateTime // start time of booking
   end            DateTime // end time of booking
   bookedAt       DateTime      @default(now())
+  deleted        Boolean       @default(false)
 }
 
 // Ability is a single action that the user can perform

--- a/src/controllers/booking/delete.ts
+++ b/src/controllers/booking/delete.ts
@@ -19,6 +19,9 @@ export async function deleteBooking(
   }
 
   const user = req.user
+  console.log(
+    `User: ${user.id} (${user.telegramUserName}) is deleting booking: ${bookingId}`
+  )
   const booking = await getBookingById(bookingId)
 
   await Policy.Authorize(

--- a/src/controllers/booking/list.ts
+++ b/src/controllers/booking/list.ts
@@ -38,14 +38,19 @@ export async function getUserBookingsController(
   req: Request,
   res: Response
 ): Promise<void> {
-  const userId = req.query.userId as string | undefined
+  const userIdString = req.query.userId as string | undefined
 
-  if (!userId) {
+  if (!userIdString) {
     throw new HttpException('Query missing userId', HttpCode.BadRequest)
+  }
+
+  const userId = parseInt(userIdString)
+  if (Number.isNaN(userId)) {
+    throw new HttpException('Query userId is not a number', HttpCode.BadRequest)
   }
 
   await Policy.Authorize(listBookingsAction, Policy.viewBookingPolicy())
 
-  const bookings = await getUserBookings(parseInt(userId))
+  const bookings = await getUserBookings(userId)
   res.json(bookings)
 }

--- a/src/middlewares/checks.test.ts
+++ b/src/middlewares/checks.test.ts
@@ -159,6 +159,7 @@ describe('check conflicting booking', () => {
     userOrgId: normalOrg.id,
     bookedAt: new Date(),
     bookedForOrgId: null,
+    deleted: false,
   }
 
   const conflictingBooking: Booking = {
@@ -171,6 +172,7 @@ describe('check conflicting booking', () => {
     userOrgId: normalOrg.id,
     bookedAt: new Date(),
     bookedForOrgId: null,
+    deleted: false,
   }
 
   test('check returns true for conflictingBooking', async () => {
@@ -202,6 +204,7 @@ describe('check stacked bookings', () => {
     venueId: venue.id,
     bookedAt: new Date(),
     bookedForOrgId: null,
+    deleted: false,
   }
 
   const validNewBooking: BookingPayload = {
@@ -232,6 +235,7 @@ describe('check stacked bookings', () => {
     venueId: venue.id,
     bookedAt: new Date(),
     bookedForOrgId: null,
+    deleted: false,
   }
 
   const validAdminBooking: BookingPayload = {

--- a/src/middlewares/checks.ts
+++ b/src/middlewares/checks.ts
@@ -170,9 +170,18 @@ export async function checkConflictingBooking(
   const endTime = booking.end
   const conflicting = await prisma.booking.findFirst({
     where: {
-      start: {
-        lt: endTime,
-      },
+      AND: [
+        {
+          start: {
+            lt: endTime,
+          },
+        },
+        {
+          deleted: {
+            not: true,
+          },
+        },
+      ],
       id: typeof exclude !== undefined ? { not: exclude } : {},
       venueId: booking.venueId,
     },
@@ -220,7 +229,16 @@ export async function checkStackedBookings(booking: BookingPayload) {
       },
     ],
     where: {
-      end: { lte: start },
+      AND: [
+        {
+          end: { lte: start },
+        },
+        {
+          deleted: {
+            not: true,
+          },
+        },
+      ],
       venueId,
       userOrgId,
     },
@@ -233,7 +251,16 @@ export async function checkStackedBookings(booking: BookingPayload) {
       },
     ],
     where: {
-      start: { gte: end },
+      AND: [
+        {
+          start: { gte: end },
+        },
+        {
+          deleted: {
+            not: true,
+          },
+        },
+      ],
       venueId,
       userOrgId,
     },

--- a/src/services/bookings.test.ts
+++ b/src/services/bookings.test.ts
@@ -86,11 +86,17 @@ describe('delete bookings', () => {
     })
 
     prismaMock.booking.findFirst.mockResolvedValueOnce(testBooking)
-    prismaMock.booking.delete.mockResolvedValue(testBooking)
+    prismaMock.booking.update.mockResolvedValue({
+      ...testBooking,
+      deleted: true,
+    })
 
     await expect(
       destroyBooking(testBooking.id, testBooking.userId)
-    ).resolves.toEqual(testBooking)
+    ).resolves.toEqual({
+      ...testBooking,
+      deleted: true,
+    })
     await expect(getBookingById(testBooking.id)).resolves.toEqual(undefined)
   })
 

--- a/src/services/test/utils.ts
+++ b/src/services/test/utils.ts
@@ -37,6 +37,7 @@ export function generateRandomBooking(booking?: Partial<Booking>): Booking {
     end: faker.datatype.datetime(),
     bookedAt: faker.datatype.datetime(),
     bookedForOrgId: generateRandomTableId(),
+    deleted: false,
     ...booking,
   }
 }


### PR DESCRIPTION
## PR Description

This PR adds an audit trail for a bug regarding deleted / missing bookings by doing the following:

- Implementing soft delete for bookings
- Adding a logging message for deleting bookings

The reason for this change is that I suspect the deleted bookings are caused by admin users accidentally deleting the specific bookings.
There is only a single place in the backend where `prisma.bookings.delete` is called - which is in the delete function for the bookings service. Thus this makes it unlikely that the bookings can just randomly disappear without reason.

However, due to the lack of appropriate logging, there is insufficient information to determine the cause of the missing bookings.
These changes will improve the audit trail for changes to bookings.

### Additional Fixes

- Additional validation for getUserBookingsController id number validation

