### PR TITLE
Missing bookings extended audit trail

### DIFF
--- a/src/controllers/booking/create.test.ts
+++ b/src/controllers/booking/create.test.ts
@@ -2,7 +2,7 @@ import { getVenueRoles } from './../../services/venues'
 import { getMockReq, getMockRes } from '@jest-mock/express'
 import * as Policy from '../../policy'
 import { RequestWithUser } from '../../interfaces/auth.interface'
-import { UnauthorizedException } from '../../exceptions/'
+import { HttpCode, HttpException, UnauthorizedException } from '../../exceptions/'
 import {
   getUserAbilities,
   getUserOrgs,
@@ -81,9 +81,14 @@ describe('Test create booking handler', () => {
       },
     })
 
-    await expect(createBooking(req, res)).rejects.toBeInstanceOf(
-      UnauthorizedException
-    )
+    try {
+      await createBooking(req, res)
+    } catch (e) {
+      const exception = e as HttpException
+      expect(exception).toBeInstanceOf(HttpException)
+      expect(exception.status).toBe(HttpCode.Unauthorized)
+      expect(exception.message).toMatch(/Requires authentication/i)
+    }
   })
 
   test('Should return 401 not authorized', async () => {

--- a/src/controllers/booking/create.ts
+++ b/src/controllers/booking/create.ts
@@ -1,4 +1,5 @@
 import { Response } from 'express'
+import { HttpCode, HttpException } from '@exceptions/HttpException'
 import { RequestWithUser } from '@/interfaces/auth.interface'
 import { addBooking } from '@services/bookings'
 import { BookingSchema } from '@/interfaces/booking.interface'
@@ -11,6 +12,9 @@ export async function createBooking(
   res: Response
 ): Promise<void> {
   const booking = BookingSchema.parse(req.body)
+  if (!req.user) {
+    throw new HttpException('Requires authentication', HttpCode.Unauthorized)
+  }
   const bookingPayload = {
     end: booking.end,
     eventName: booking.eventName,
@@ -27,5 +31,12 @@ export async function createBooking(
   )
 
   const inserted = await addBooking(bookingPayload)
+
+  // Logging event of a new Booking
+  const user = req.user
+  console.log(
+    `User: ${user.id} (${user.telegramUserName}) is creating booking: ${inserted.id}`
+  )
+
   res.status(200).json({ result: [inserted] })
 }

--- a/src/controllers/booking/update.ts
+++ b/src/controllers/booking/update.ts
@@ -29,6 +29,12 @@ export async function editBooking(
     userOrgId: booking.orgId,
   }
 
+  // Logging event of updating a Booking
+  const user = req.user
+  console.log(
+    `User: ${user.id} (${user.telegramUserName}) is updating booking: ${bookingId}`
+  )
+
   await Policy.Authorize(
     updateBookingAction,
     Policy.updateBookingPolicy(bookingPayload, req.user),


### PR DESCRIPTION
## PR Description
This PR extends an audit trail for a bug regarding deleted / missing bookings by doing the following:

* Adding a logging message for creating bookings
* Adding a logging message for updating bookings

As mentioned in #165 by @zsh-eng 
> The reason for this change is that I suspect the deleted bookings are caused by admin users accidentally deleting the specific bookings. There is only a single place in the backend where `prisma.bookings.delete` is called - which is in the delete function for the bookings service. Thus this makes it unlikely that the bookings can just randomly disappear without reason.

> However, due to the lack of appropriate logging, there is insufficient information to determine the cause of the missing bookings. These changes will improve the audit trail for changes to bookings.

The reason for this change is that we suspect that the missing bookings are not being tracked by the database after being created or updated. These changes will improve the audit trail, providing us with a way to verify successful creation and updating of new bookings.